### PR TITLE
Add `panic` statement and variant matching through a pointer

### DIFF
--- a/ReCode
+++ b/ReCode
@@ -491,7 +491,7 @@ def compiler(skip_tests=False, save=False):
 
         compiler_command = ["Runner", "build/compiler/compiler.ir", "-o", build_dir, "-n", "test", test_dir]
         if run(compiler_command, check=False).returncode != 0:
-            trace(*compiler_command)
+            # trace(*compiler_command)
             exit(1)
 
         expected_execute = test_data.get("execute", {})

--- a/code/compiler/checker/checker.code
+++ b/code/compiler/checker/checker.code
@@ -35,60 +35,59 @@ proc (^Checker).check_builtin_package(self, anon parsed_package: ^parsed.Package
         self.current_source = module.source
         let item = module.statements.first
         while item != null {
-            let statement = item.value
-            switch statement {
-                is parsed.Type_Statement as type_statement {
+            switch item.value {
+                is ^parsed.Type_Statement as type_statement {
                     self.check_builtin_type_statement(type_statement)
                 }
-                is parsed.Assignment_Statement as _ignored {
+                is ^parsed.Assignment_Statement {
                     panic "Not supported yet: parsed.Assignment_Statement"
                 }
-                is parsed.Block_Statement as _ignored {
+                is ^parsed.Block_Statement {
                     panic "Not supported yet: parsed.Block_Statement"
                 }
-                is parsed.Break_Statement as _ignored {
+                is ^parsed.Break_Statement {
                     panic "Not supported yet: parsed.Break_Statement"
                 }
-                is parsed.Const_Statement as _ignored {
+                is ^parsed.Const_Statement {
                     panic "Not supported yet: parsed.Const_Statement"
                 }
-                is parsed.Defer_Statement as _ignored {
+                is ^parsed.Defer_Statement {
                     panic "Not supported yet: parsed.Defer_Statement"
                 }
-                is parsed.Expression_Statement as _ignored {
+                is ^parsed.Expression_Statement {
                     panic "Not supported yet: parsed.Expression_Statement"
                 }
-                is parsed.If_Statement as _ignored {
+                is ^parsed.If_Statement {
                     panic "Not supported yet: parsed.If_Statement"
                 }
-                is parsed.Import_Statement as _ignored {
+                is ^parsed.Import_Statement {
                     panic "Not supported yet: parsed.Import_Statement"
                 }
-                is parsed.Loop_Statement as _ignored {
+                is ^parsed.Loop_Statement {
                     panic "Not supported yet: parsed.Loop_Statement"
                 }
-                is parsed.Procedure_Statement as _ignored {
+                is ^parsed.Procedure_Statement {
                     panic "Not supported yet: parsed.Procedure_Statement"
                 }
-                is parsed.Raise_Statement as _ignored {
+                is ^parsed.Raise_Statement {
                     panic "Not supported yet: parsed.Raise_Statement"
                 }
-                is parsed.Return_Statement as _ignored {
+                is ^parsed.Return_Statement {
                     panic "Not supported yet: parsed.Return_Statement"
                 }
-                is parsed.Switch_Statement as _ignored {
+                is ^parsed.Switch_Statement {
                     panic "Not supported yet: parsed.Switch_Statement"
                 }
-                is parsed.Variable_Statement as _ignored {
+                is ^parsed.Variable_Statement {
                     panic "Not supported yet: parsed.Variable_Statement"
                 }
-                is parsed.While_Statement as _ignored {
+                is ^parsed.While_Statement {
                     panic "Not supported yet: parsed.While_Statement"
                 }
-                is parsed.Yield_Statement as _ignored {
+                is ^parsed.Yield_Statement {
                     panic "Not supported yet: parsed.Yield_Statement"
                 }
-                is nil {
+                is ^nil {
                 }
             }
             item = item.next
@@ -98,23 +97,22 @@ proc (^Checker).check_builtin_package(self, anon parsed_package: ^parsed.Package
     return
 }
 
-proc (^Checker).check_builtin_type_statement(self, anon type_statement: parsed.Type_Statement) !> error.Error {
+proc (^Checker).check_builtin_type_statement(self, anon type_statement: ^parsed.Type_Statement) !> error.Error {
     self.current_source_position = type_statement.super.source_position
-    let specifier = type_statement.specifier
     let is_builtin = false
-    switch specifier {
-        is parsed.Builtin_Type_Specifier as _ignored {
+    switch type_statement.specifier {
+        is ^parsed.Builtin_Type_Specifier {
             is_builtin = true
         }
-        is parsed.External_Type_Specifier as _ignored {
+        is ^parsed.External_Type_Specifier {
         }
-        is parsed.Struct_Type_Specifier as _ignored {
+        is ^parsed.Struct_Type_Specifier {
         }
-        is parsed.Trait_Type_Specifier as _ignored {
+        is ^parsed.Trait_Type_Specifier {
         }
-        is parsed.Variant_Type_Specifier as _ignored {
+        is ^parsed.Variant_Type_Specifier {
         }
-        is nil {
+        is ^nil {
         }
     }
     if not is_builtin {
@@ -152,60 +150,59 @@ proc (^Checker).check_package(self, anon parsed_package: ^parsed.Package) -> ^ch
 
         let item = module.statements.first
         while item != null {
-            let statement = item.value
-            switch statement {
-                is parsed.Procedure_Statement as procedure_statement {
+            switch item.value {
+                is ^parsed.Procedure_Statement as procedure_statement {
                     self.check_procedure_statement(procedure_statement)
                 }
-                is parsed.Assignment_Statement as _ignored {
+                is ^parsed.Assignment_Statement {
                     panic "Not supported yet: parsed.Assignment_Statement"
                 }
-                is parsed.Block_Statement as _ignored {
+                is ^parsed.Block_Statement {
                     panic "Not supported yet: parsed.Block_Statement"
                 }
-                is parsed.Break_Statement as _ignored {
+                is ^parsed.Break_Statement {
                     panic "Not supported yet: parsed.Break_Statement"
                 }
-                is parsed.Const_Statement as _ignored {
+                is ^parsed.Const_Statement {
                     panic "Not supported yet: parsed.Const_Statement"
                 }
-                is parsed.Defer_Statement as _ignored {
+                is ^parsed.Defer_Statement {
                     panic "Not supported yet: parsed.Defer_Statement"
                 }
-                is parsed.Expression_Statement as _ignored {
+                is ^parsed.Expression_Statement {
                     panic "Not supported yet: parsed.Expression_Statement"
                 }
-                is parsed.If_Statement as _ignored {
+                is ^parsed.If_Statement {
                     panic "Not supported yet: parsed.If_Statement"
                 }
-                is parsed.Import_Statement as _ignored {
+                is ^parsed.Import_Statement {
                     panic "Not supported yet: parsed.Import_Statement"
                 }
-                is parsed.Loop_Statement as _ignored {
+                is ^parsed.Loop_Statement {
                     panic "Not supported yet: parsed.Loop_Statement"
                 }
-                is parsed.Raise_Statement as _ignored {
+                is ^parsed.Raise_Statement {
                     panic "Not supported yet: parsed.Raise_Statement"
                 }
-                is parsed.Return_Statement as _ignored {
+                is ^parsed.Return_Statement {
                     panic "Not supported yet: parsed.Return_Statement"
                 }
-                is parsed.Switch_Statement as _ignored {
+                is ^parsed.Switch_Statement {
                     panic "Not supported yet: parsed.Switch_Statement"
                 }
-                is parsed.Type_Statement as _ignored {
+                is ^parsed.Type_Statement {
                     panic "Not supported yet: parsed.Type_Statement"
                 }
-                is parsed.Variable_Statement as _ignored {
+                is ^parsed.Variable_Statement {
                     panic "Not supported yet: parsed.Variable_Statement"
                 }
-                is parsed.While_Statement as _ignored {
+                is ^parsed.While_Statement {
                     panic "Not supported yet: parsed.While_Statement"
                 }
-                is parsed.Yield_Statement as _ignored {
+                is ^parsed.Yield_Statement {
                     panic "Not supported yet: parsed.Yield_Statement"
                 }
-                is nil {
+                is ^nil {
                 }
             }
             item = item.next
@@ -216,7 +213,7 @@ proc (^Checker).check_package(self, anon parsed_package: ^parsed.Package) -> ^ch
     return checked_package
 }
 
-proc (^Checker).check_procedure_statement(self, anon procedure_statement: parsed.Procedure_Statement) !> error.Error {
+proc (^Checker).check_procedure_statement(self, anon procedure_statement: ^parsed.Procedure_Statement) !> error.Error {
     self.current_source_position = procedure_statement.super.source_position
     let name = procedure_statement.name.super.lexeme
 
@@ -235,58 +232,58 @@ proc (^Checker).check_procedure_statement(self, anon procedure_statement: parsed
     if not procedure_statement.is_external and procedure_statement.body != null {
         self.return_type = return_type
         switch procedure_statement.body {
-            is parsed.Block_Statement as block_statement {
+            is ^parsed.Block_Statement as block_statement {
                 body = self.check_block_statement(block_statement)
             }
-            is parsed.Assignment_Statement as _ignored {
+            is ^parsed.Assignment_Statement {
                 panic "Not supported yet: parsed.Assignment_Statement"
             }
-            is parsed.Break_Statement as _ignored {
+            is ^parsed.Break_Statement {
                 panic "Not supported yet: parsed.Break_Statement"
             }
-            is parsed.Const_Statement as _ignored {
+            is ^parsed.Const_Statement {
                 panic "Not supported yet: parsed.Const_Statement"
             }
-            is parsed.Defer_Statement as _ignored {
+            is ^parsed.Defer_Statement {
                 panic "Not supported yet: parsed.Defer_Statement"
             }
-            is parsed.Expression_Statement as _ignored {
+            is ^parsed.Expression_Statement {
                 panic "Not supported yet: parsed.Expression_Statement"
             }
-            is parsed.If_Statement as _ignored {
+            is ^parsed.If_Statement {
                 panic "Not supported yet: parsed.If_Statement"
             }
-            is parsed.Import_Statement as _ignored {
+            is ^parsed.Import_Statement {
                 panic "Not supported yet: parsed.Import_Statement"
             }
-            is parsed.Loop_Statement as _ignored {
+            is ^parsed.Loop_Statement {
                 panic "Not supported yet: parsed.Loop_Statement"
             }
-            is parsed.Procedure_Statement as _ignored {
+            is ^parsed.Procedure_Statement {
                 panic "Not supported yet: parsed.Procedure_Statement"
             }
-            is parsed.Raise_Statement as _ignored {
+            is ^parsed.Raise_Statement {
                 panic "Not supported yet: parsed.Raise_Statement"
             }
-            is parsed.Return_Statement as _ignored {
+            is ^parsed.Return_Statement {
                 panic "Not supported yet: parsed.Return_Statement"
             }
-            is parsed.Switch_Statement as _ignored {
+            is ^parsed.Switch_Statement {
                 panic "Not supported yet: parsed.Switch_Statement"
             }
-            is parsed.Type_Statement as _ignored {
+            is ^parsed.Type_Statement {
                 panic "Not supported yet: parsed.Type_Statement"
             }
-            is parsed.Variable_Statement as _ignored {
+            is ^parsed.Variable_Statement {
                 panic "Not supported yet: parsed.Variable_Statement"
             }
-            is parsed.While_Statement as _ignored {
+            is ^parsed.While_Statement {
                 panic "Not supported yet: parsed.While_Statement"
             }
-            is parsed.Yield_Statement as _ignored {
+            is ^parsed.Yield_Statement {
                 panic "Not supported yet: parsed.Yield_Statement"
             }
-            is nil {
+            is ^nil {
             }
         }
     }
@@ -300,7 +297,7 @@ proc (^Checker).check_procedure_statement(self, anon procedure_statement: parsed
     return
 }
 
-proc (^Checker).check_block_statement(self, anon parsed_block: parsed.Block_Statement) -> ^checked.Statement !> error.Error {
+proc (^Checker).check_block_statement(self, anon parsed_block: ^parsed.Block_Statement) -> ^checked.Statement !> error.Error {
     let statements = collections.List<^checked.Statement>()
     let item = parsed_block.statements.first
     while item != null {
@@ -315,64 +312,64 @@ proc (^Checker).check_block_statement(self, anon parsed_block: parsed.Block_Stat
 
 proc (^Checker).check_statement(self, anon parsed_statement: ^parsed.Statement) -> ^checked.Statement !> error.Error {
     switch parsed_statement {
-        is parsed.Block_Statement as block_statement {
+        is ^parsed.Block_Statement as block_statement {
             return self.check_block_statement(block_statement)
         }
-        is parsed.Return_Statement as return_statement {
+        is ^parsed.Return_Statement as return_statement {
             return self.check_return_statement(return_statement)
         }
-        is parsed.Assignment_Statement as _ignored {
+        is ^parsed.Assignment_Statement {
             panic "Not supported yet: parsed.Assignment_Statement"
         }
-        is parsed.Break_Statement as _ignored {
+        is ^parsed.Break_Statement {
             panic "Not supported yet: parsed.Break_Statement"
         }
-        is parsed.Const_Statement as _ignored {
+        is ^parsed.Const_Statement {
             panic "Not supported yet: parsed.Const_Statement"
         }
-        is parsed.Defer_Statement as _ignored {
+        is ^parsed.Defer_Statement {
             panic "Not supported yet: parsed.Defer_Statement"
         }
-        is parsed.Expression_Statement as _ignored {
+        is ^parsed.Expression_Statement {
             panic "Not supported yet: parsed.Expression_Statement"
         }
-        is parsed.If_Statement as _ignored {
+        is ^parsed.If_Statement {
             panic "Not supported yet: parsed.If_Statement"
         }
-        is parsed.Import_Statement as _ignored {
+        is ^parsed.Import_Statement {
             panic "Not supported yet: parsed.Import_Statement"
         }
-        is parsed.Loop_Statement as _ignored {
+        is ^parsed.Loop_Statement {
             panic "Not supported yet: parsed.Loop_Statement"
         }
-        is parsed.Procedure_Statement as _ignored {
+        is ^parsed.Procedure_Statement {
             panic "Not supported yet: parsed.Procedure_Statement"
         }
-        is parsed.Raise_Statement as _ignored {
+        is ^parsed.Raise_Statement {
             panic "Not supported yet: parsed.Raise_Statement"
         }
-        is parsed.Switch_Statement as _ignored {
+        is ^parsed.Switch_Statement {
             panic "Not supported yet: parsed.Switch_Statement"
         }
-        is parsed.Type_Statement as _ignored {
+        is ^parsed.Type_Statement {
             panic "Not supported yet: parsed.Type_Statement"
         }
-        is parsed.Variable_Statement as _ignored {
+        is ^parsed.Variable_Statement {
             panic "Not supported yet: parsed.Variable_Statement"
         }
-        is parsed.While_Statement as _ignored {
+        is ^parsed.While_Statement {
             panic "Not supported yet: parsed.While_Statement"
         }
-        is parsed.Yield_Statement as _ignored {
+        is ^parsed.Yield_Statement {
             panic "Not supported yet: parsed.Yield_Statement"
         }
-        is nil {
+        is ^nil {
         }
     }
     raise self.error("Unsupported statement")
 }
 
-proc (^Checker).check_return_statement(self, anon return_statement: parsed.Return_Statement) -> ^checked.Statement !> error.Error {
+proc (^Checker).check_return_statement(self, anon return_statement: ^parsed.Return_Statement) -> ^checked.Statement !> error.Error {
     self.current_source_position = return_statement.super.source_position
     let expression: ^checked.Expression = null
     if return_statement.expression != null {
@@ -385,118 +382,118 @@ proc (^Checker).check_return_statement(self, anon return_statement: parsed.Retur
 
 proc (^Checker).check_expression(self, anon parsed_expression: ^parsed.Expression, expected_type: ^checked.Type) -> ^checked.Expression !> error.Error {
     switch parsed_expression {
-        is parsed.Integer_Expression as integer_expression {
+        is ^parsed.Integer_Expression as integer_expression {
             return self.check_integer_expression(integer_expression, expected_type: expected_type)
         }
-        is parsed.Add_Expression as _ignored {
+        is ^parsed.Add_Expression {
             panic "Not supported yet: parsed.Add_Expression"
         }
-        is parsed.Address_Of_Expression as _ignored {
+        is ^parsed.Address_Of_Expression {
             panic "Not supported yet: parsed.Address_Of_Expression"
         }
-        is parsed.Alloc_Expression as _ignored {
+        is ^parsed.Alloc_Expression {
             panic "Not supported yet: parsed.Alloc_Expression"
         }
-        is parsed.Array_Access_Expression as _ignored {
+        is ^parsed.Array_Access_Expression {
             panic "Not supported yet: parsed.Array_Access_Expression"
         }
-        is parsed.Block_Expression as _ignored {
+        is ^parsed.Block_Expression {
             panic "Not supported yet: parsed.Block_Expression"
         }
-        is parsed.Call_Expression as _ignored {
+        is ^parsed.Call_Expression {
             panic "Not supported yet: parsed.Call_Expression"
         }
-        is parsed.Character_Expression as _ignored {
+        is ^parsed.Character_Expression {
             panic "Not supported yet: parsed.Character_Expression"
         }
-        is parsed.Dereference_Expression as _ignored {
+        is ^parsed.Dereference_Expression {
             panic "Not supported yet: parsed.Dereference_Expression"
         }
-        is parsed.Divide_Expression as _ignored {
+        is ^parsed.Divide_Expression {
             panic "Not supported yet: parsed.Divide_Expression"
         }
-        is parsed.Equals_Expression as _ignored {
+        is ^parsed.Equals_Expression {
             panic "Not supported yet: parsed.Equals_Expression"
         }
-        is parsed.Greater_Expression as _ignored {
+        is ^parsed.Greater_Expression {
             panic "Not supported yet: parsed.Greater_Expression"
         }
-        is parsed.Greater_Or_Equals_Expression as _ignored {
+        is ^parsed.Greater_Or_Equals_Expression {
             panic "Not supported yet: parsed.Greater_Or_Equals_Expression"
         }
-        is parsed.Identifier_Expression as _ignored {
+        is ^parsed.Identifier_Expression {
             panic "Not supported yet: parsed.Identifier_Expression"
         }
-        is parsed.Is_Expression as _ignored {
+        is ^parsed.Is_Expression {
             panic "Not supported yet: parsed.Is_Expression"
         }
-        is parsed.Less_Expression as _ignored {
+        is ^parsed.Less_Expression {
             panic "Not supported yet: parsed.Less_Expression"
         }
-        is parsed.Less_Or_Equals_Expression as _ignored {
+        is ^parsed.Less_Or_Equals_Expression {
             panic "Not supported yet: parsed.Less_Or_Equals_Expression"
         }
-        is parsed.Logic_And_Expression as _ignored {
+        is ^parsed.Logic_And_Expression {
             panic "Not supported yet: parsed.Logic_And_Expression"
         }
-        is parsed.Logic_Or_Expression as _ignored {
+        is ^parsed.Logic_Or_Expression {
             panic "Not supported yet: parsed.Logic_Or_Expression"
         }
-        is parsed.Member_Access_Expression as _ignored {
+        is ^parsed.Member_Access_Expression {
             panic "Not supported yet: parsed.Member_Access_Expression"
         }
-        is parsed.Modulo_Expression as _ignored {
+        is ^parsed.Modulo_Expression {
             panic "Not supported yet: parsed.Modulo_Expression"
         }
-        is parsed.Multiply_Expression as _ignored {
+        is ^parsed.Multiply_Expression {
             panic "Not supported yet: parsed.Multiply_Expression"
         }
-        is parsed.Negate_Expression as _ignored {
+        is ^parsed.Negate_Expression {
             panic "Not supported yet: parsed.Negate_Expression"
         }
-        is parsed.Not_Expression as _ignored {
+        is ^parsed.Not_Expression {
             panic "Not supported yet: parsed.Not_Expression"
         }
-        is parsed.Not_Equals_Expression as _ignored {
+        is ^parsed.Not_Equals_Expression {
             panic "Not supported yet: parsed.Not_Equals_Expression"
         }
-        is parsed.Subtract_Expression as _ignored {
+        is ^parsed.Subtract_Expression {
             panic "Not supported yet: parsed.Subtract_Expression"
         }
-        is parsed.String_Expression as _ignored {
+        is ^parsed.String_Expression {
             panic "Not supported yet: parsed.String_Expression"
         }
-        is parsed.Try_Expression as _ignored {
+        is ^parsed.Try_Expression {
             panic "Not supported yet: parsed.Try_Expression"
         }
-        is parsed.Type_Alignment_Expression as _ignored {
+        is ^parsed.Type_Alignment_Expression {
             panic "Not supported yet: parsed.Type_Alignment_Expression"
         }
-        is parsed.Type_Size_Expression as _ignored {
+        is ^parsed.Type_Size_Expression {
             panic "Not supported yet: parsed.Type_Size_Expression"
         }
-        is parsed.Type_Specialization_Expression as _ignored {
+        is ^parsed.Type_Specialization_Expression {
             panic "Not supported yet: parsed.Type_Specialization_Expression"
         }
-        is nil {
+        is ^nil {
         }
     }
     raise self.error("Unsupported expression")
 }
 
-proc (^Checker).check_integer_expression(self, anon integer_expression: parsed.Integer_Expression, expected_type: ^checked.Type) -> ^checked.Expression !> error.Error {
+proc (^Checker).check_integer_expression(self, anon integer_expression: ^parsed.Integer_Expression, expected_type: ^checked.Type) -> ^checked.Expression !> error.Error {
     self.current_source_position = integer_expression.source_position
     let expression_type = expected_type
     if expression_type == null {
         let i32_symbol = self.builtin_symbols.find("i32")
         switch i32_symbol {
-            is checked.Type_Symbol as type_symbol {
+            is ^checked.Type_Symbol as type_symbol {
                 expression_type = type_symbol.type
             }
-            is checked.Procedure_Symbol as _ignored {
+            is ^checked.Procedure_Symbol {
                 panic "Not supported yet: checked.Procedure_Symbol"
             }
-            is nil {
+            is ^nil {
             }
         }
     }
@@ -511,7 +508,7 @@ proc (^Checker).check_integer_expression(self, anon integer_expression: parsed.I
 
 proc (^Checker).resolve_type(self, anon parsed_type: ^parsed.Type) -> ^checked.Type !> error.Error {
     switch parsed_type {
-        is parsed.Named_Type as named_type {
+        is ^parsed.Named_Type as named_type {
             self.current_source_position = named_type.source_position
             let name = named_type.name.super.lexeme
             let symbol = self.global_symbols.find(name)
@@ -522,33 +519,33 @@ proc (^Checker).resolve_type(self, anon parsed_type: ^parsed.Type) -> ^checked.T
                 raise self.error("Unknown type")
             }
             switch symbol {
-                is checked.Type_Symbol as type_symbol {
+                is ^checked.Type_Symbol as type_symbol {
                     return type_symbol.type
                 }
-                is checked.Procedure_Symbol as _ignored {
+                is ^checked.Procedure_Symbol {
                     panic "Not supported yet: checked.Procedure_Symbol"
                 }
-                is nil {
+                is ^nil {
                 }
             }
             raise self.error("Symbol is not a type")
         }
-        is parsed.Multi_Pointer_Type as _ignored {
+        is ^parsed.Multi_Pointer_Type {
             panic "Not supported yet: parsed.Multi_Pointer_Type"
         }
-        is parsed.Optional_Type as _ignored {
+        is ^parsed.Optional_Type {
             panic "Not supported yet: parsed.Optional_Type"
         }
-        is parsed.Pointer_Type as _ignored {
+        is ^parsed.Pointer_Type {
             panic "Not supported yet: parsed.Pointer_Type"
         }
-        is parsed.Procedure_Type as _ignored {
+        is ^parsed.Procedure_Type {
             panic "Not supported yet: parsed.Procedure_Type"
         }
-        is parsed.Trait_Receiver_Type as _ignored {
+        is ^parsed.Trait_Receiver_Type {
             panic "Not supported yet: parsed.Trait_Receiver_Type"
         }
-        is nil {
+        is ^nil {
         }
     }
     raise self.error("Unsupported type")

--- a/code/compiler/checker/checker.code
+++ b/code/compiler/checker/checker.code
@@ -41,52 +41,52 @@ proc (^Checker).check_builtin_package(self, anon parsed_package: ^parsed.Package
                     self.check_builtin_type_statement(type_statement)
                 }
                 is parsed.Assignment_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Assignment_Statement")
+                    panic "Not supported yet: parsed.Assignment_Statement"
                 }
                 is parsed.Block_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Block_Statement")
+                    panic "Not supported yet: parsed.Block_Statement"
                 }
                 is parsed.Break_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Break_Statement")
+                    panic "Not supported yet: parsed.Break_Statement"
                 }
                 is parsed.Const_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Const_Statement")
+                    panic "Not supported yet: parsed.Const_Statement"
                 }
                 is parsed.Defer_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Defer_Statement")
+                    panic "Not supported yet: parsed.Defer_Statement"
                 }
                 is parsed.Expression_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Expression_Statement")
+                    panic "Not supported yet: parsed.Expression_Statement"
                 }
                 is parsed.If_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.If_Statement")
+                    panic "Not supported yet: parsed.If_Statement"
                 }
                 is parsed.Import_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Import_Statement")
+                    panic "Not supported yet: parsed.Import_Statement"
                 }
                 is parsed.Loop_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Loop_Statement")
+                    panic "Not supported yet: parsed.Loop_Statement"
                 }
                 is parsed.Procedure_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Procedure_Statement")
+                    panic "Not supported yet: parsed.Procedure_Statement"
                 }
                 is parsed.Raise_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Raise_Statement")
+                    panic "Not supported yet: parsed.Raise_Statement"
                 }
                 is parsed.Return_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Return_Statement")
+                    panic "Not supported yet: parsed.Return_Statement"
                 }
                 is parsed.Switch_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Switch_Statement")
+                    panic "Not supported yet: parsed.Switch_Statement"
                 }
                 is parsed.Variable_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Variable_Statement")
+                    panic "Not supported yet: parsed.Variable_Statement"
                 }
                 is parsed.While_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.While_Statement")
+                    panic "Not supported yet: parsed.While_Statement"
                 }
                 is parsed.Yield_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Yield_Statement")
+                    panic "Not supported yet: parsed.Yield_Statement"
                 }
                 is nil {
                 }
@@ -158,52 +158,52 @@ proc (^Checker).check_package(self, anon parsed_package: ^parsed.Package) -> ^ch
                     self.check_procedure_statement(procedure_statement)
                 }
                 is parsed.Assignment_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Assignment_Statement")
+                    panic "Not supported yet: parsed.Assignment_Statement"
                 }
                 is parsed.Block_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Block_Statement")
+                    panic "Not supported yet: parsed.Block_Statement"
                 }
                 is parsed.Break_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Break_Statement")
+                    panic "Not supported yet: parsed.Break_Statement"
                 }
                 is parsed.Const_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Const_Statement")
+                    panic "Not supported yet: parsed.Const_Statement"
                 }
                 is parsed.Defer_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Defer_Statement")
+                    panic "Not supported yet: parsed.Defer_Statement"
                 }
                 is parsed.Expression_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Expression_Statement")
+                    panic "Not supported yet: parsed.Expression_Statement"
                 }
                 is parsed.If_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.If_Statement")
+                    panic "Not supported yet: parsed.If_Statement"
                 }
                 is parsed.Import_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Import_Statement")
+                    panic "Not supported yet: parsed.Import_Statement"
                 }
                 is parsed.Loop_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Loop_Statement")
+                    panic "Not supported yet: parsed.Loop_Statement"
                 }
                 is parsed.Raise_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Raise_Statement")
+                    panic "Not supported yet: parsed.Raise_Statement"
                 }
                 is parsed.Return_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Return_Statement")
+                    panic "Not supported yet: parsed.Return_Statement"
                 }
                 is parsed.Switch_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Switch_Statement")
+                    panic "Not supported yet: parsed.Switch_Statement"
                 }
                 is parsed.Type_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Type_Statement")
+                    panic "Not supported yet: parsed.Type_Statement"
                 }
                 is parsed.Variable_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Variable_Statement")
+                    panic "Not supported yet: parsed.Variable_Statement"
                 }
                 is parsed.While_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.While_Statement")
+                    panic "Not supported yet: parsed.While_Statement"
                 }
                 is parsed.Yield_Statement as _ignored {
-                    self.panic("Not supported yet: parsed.Yield_Statement")
+                    panic "Not supported yet: parsed.Yield_Statement"
                 }
                 is nil {
                 }
@@ -239,52 +239,52 @@ proc (^Checker).check_procedure_statement(self, anon procedure_statement: parsed
                 body = self.check_block_statement(block_statement)
             }
             is parsed.Assignment_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Assignment_Statement")
+                panic "Not supported yet: parsed.Assignment_Statement"
             }
             is parsed.Break_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Break_Statement")
+                panic "Not supported yet: parsed.Break_Statement"
             }
             is parsed.Const_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Const_Statement")
+                panic "Not supported yet: parsed.Const_Statement"
             }
             is parsed.Defer_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Defer_Statement")
+                panic "Not supported yet: parsed.Defer_Statement"
             }
             is parsed.Expression_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Expression_Statement")
+                panic "Not supported yet: parsed.Expression_Statement"
             }
             is parsed.If_Statement as _ignored {
-                self.panic("Not supported yet: parsed.If_Statement")
+                panic "Not supported yet: parsed.If_Statement"
             }
             is parsed.Import_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Import_Statement")
+                panic "Not supported yet: parsed.Import_Statement"
             }
             is parsed.Loop_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Loop_Statement")
+                panic "Not supported yet: parsed.Loop_Statement"
             }
             is parsed.Procedure_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Procedure_Statement")
+                panic "Not supported yet: parsed.Procedure_Statement"
             }
             is parsed.Raise_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Raise_Statement")
+                panic "Not supported yet: parsed.Raise_Statement"
             }
             is parsed.Return_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Return_Statement")
+                panic "Not supported yet: parsed.Return_Statement"
             }
             is parsed.Switch_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Switch_Statement")
+                panic "Not supported yet: parsed.Switch_Statement"
             }
             is parsed.Type_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Type_Statement")
+                panic "Not supported yet: parsed.Type_Statement"
             }
             is parsed.Variable_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Variable_Statement")
+                panic "Not supported yet: parsed.Variable_Statement"
             }
             is parsed.While_Statement as _ignored {
-                self.panic("Not supported yet: parsed.While_Statement")
+                panic "Not supported yet: parsed.While_Statement"
             }
             is parsed.Yield_Statement as _ignored {
-                self.panic("Not supported yet: parsed.Yield_Statement")
+                panic "Not supported yet: parsed.Yield_Statement"
             }
             is nil {
             }
@@ -322,49 +322,49 @@ proc (^Checker).check_statement(self, anon parsed_statement: ^parsed.Statement) 
             return self.check_return_statement(return_statement)
         }
         is parsed.Assignment_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Assignment_Statement")
+            panic "Not supported yet: parsed.Assignment_Statement"
         }
         is parsed.Break_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Break_Statement")
+            panic "Not supported yet: parsed.Break_Statement"
         }
         is parsed.Const_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Const_Statement")
+            panic "Not supported yet: parsed.Const_Statement"
         }
         is parsed.Defer_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Defer_Statement")
+            panic "Not supported yet: parsed.Defer_Statement"
         }
         is parsed.Expression_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Expression_Statement")
+            panic "Not supported yet: parsed.Expression_Statement"
         }
         is parsed.If_Statement as _ignored {
-            self.panic("Not supported yet: parsed.If_Statement")
+            panic "Not supported yet: parsed.If_Statement"
         }
         is parsed.Import_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Import_Statement")
+            panic "Not supported yet: parsed.Import_Statement"
         }
         is parsed.Loop_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Loop_Statement")
+            panic "Not supported yet: parsed.Loop_Statement"
         }
         is parsed.Procedure_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Procedure_Statement")
+            panic "Not supported yet: parsed.Procedure_Statement"
         }
         is parsed.Raise_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Raise_Statement")
+            panic "Not supported yet: parsed.Raise_Statement"
         }
         is parsed.Switch_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Switch_Statement")
+            panic "Not supported yet: parsed.Switch_Statement"
         }
         is parsed.Type_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Type_Statement")
+            panic "Not supported yet: parsed.Type_Statement"
         }
         is parsed.Variable_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Variable_Statement")
+            panic "Not supported yet: parsed.Variable_Statement"
         }
         is parsed.While_Statement as _ignored {
-            self.panic("Not supported yet: parsed.While_Statement")
+            panic "Not supported yet: parsed.While_Statement"
         }
         is parsed.Yield_Statement as _ignored {
-            self.panic("Not supported yet: parsed.Yield_Statement")
+            panic "Not supported yet: parsed.Yield_Statement"
         }
         is nil {
         }
@@ -389,94 +389,94 @@ proc (^Checker).check_expression(self, anon parsed_expression: ^parsed.Expressio
             return self.check_integer_expression(integer_expression, expected_type: expected_type)
         }
         is parsed.Add_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Add_Expression")
+            panic "Not supported yet: parsed.Add_Expression"
         }
         is parsed.Address_Of_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Address_Of_Expression")
+            panic "Not supported yet: parsed.Address_Of_Expression"
         }
         is parsed.Alloc_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Alloc_Expression")
+            panic "Not supported yet: parsed.Alloc_Expression"
         }
         is parsed.Array_Access_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Array_Access_Expression")
+            panic "Not supported yet: parsed.Array_Access_Expression"
         }
         is parsed.Block_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Block_Expression")
+            panic "Not supported yet: parsed.Block_Expression"
         }
         is parsed.Call_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Call_Expression")
+            panic "Not supported yet: parsed.Call_Expression"
         }
         is parsed.Character_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Character_Expression")
+            panic "Not supported yet: parsed.Character_Expression"
         }
         is parsed.Dereference_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Dereference_Expression")
+            panic "Not supported yet: parsed.Dereference_Expression"
         }
         is parsed.Divide_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Divide_Expression")
+            panic "Not supported yet: parsed.Divide_Expression"
         }
         is parsed.Equals_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Equals_Expression")
+            panic "Not supported yet: parsed.Equals_Expression"
         }
         is parsed.Greater_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Greater_Expression")
+            panic "Not supported yet: parsed.Greater_Expression"
         }
         is parsed.Greater_Or_Equals_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Greater_Or_Equals_Expression")
+            panic "Not supported yet: parsed.Greater_Or_Equals_Expression"
         }
         is parsed.Identifier_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Identifier_Expression")
+            panic "Not supported yet: parsed.Identifier_Expression"
         }
         is parsed.Is_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Is_Expression")
+            panic "Not supported yet: parsed.Is_Expression"
         }
         is parsed.Less_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Less_Expression")
+            panic "Not supported yet: parsed.Less_Expression"
         }
         is parsed.Less_Or_Equals_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Less_Or_Equals_Expression")
+            panic "Not supported yet: parsed.Less_Or_Equals_Expression"
         }
         is parsed.Logic_And_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Logic_And_Expression")
+            panic "Not supported yet: parsed.Logic_And_Expression"
         }
         is parsed.Logic_Or_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Logic_Or_Expression")
+            panic "Not supported yet: parsed.Logic_Or_Expression"
         }
         is parsed.Member_Access_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Member_Access_Expression")
+            panic "Not supported yet: parsed.Member_Access_Expression"
         }
         is parsed.Modulo_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Modulo_Expression")
+            panic "Not supported yet: parsed.Modulo_Expression"
         }
         is parsed.Multiply_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Multiply_Expression")
+            panic "Not supported yet: parsed.Multiply_Expression"
         }
         is parsed.Negate_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Negate_Expression")
+            panic "Not supported yet: parsed.Negate_Expression"
         }
         is parsed.Not_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Not_Expression")
+            panic "Not supported yet: parsed.Not_Expression"
         }
         is parsed.Not_Equals_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Not_Equals_Expression")
+            panic "Not supported yet: parsed.Not_Equals_Expression"
         }
         is parsed.Subtract_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Subtract_Expression")
+            panic "Not supported yet: parsed.Subtract_Expression"
         }
         is parsed.String_Expression as _ignored {
-            self.panic("Not supported yet: parsed.String_Expression")
+            panic "Not supported yet: parsed.String_Expression"
         }
         is parsed.Try_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Try_Expression")
+            panic "Not supported yet: parsed.Try_Expression"
         }
         is parsed.Type_Alignment_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Type_Alignment_Expression")
+            panic "Not supported yet: parsed.Type_Alignment_Expression"
         }
         is parsed.Type_Size_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Type_Size_Expression")
+            panic "Not supported yet: parsed.Type_Size_Expression"
         }
         is parsed.Type_Specialization_Expression as _ignored {
-            self.panic("Not supported yet: parsed.Type_Specialization_Expression")
+            panic "Not supported yet: parsed.Type_Specialization_Expression"
         }
         is nil {
         }
@@ -494,7 +494,7 @@ proc (^Checker).check_integer_expression(self, anon integer_expression: parsed.I
                 expression_type = type_symbol.type
             }
             is checked.Procedure_Symbol as _ignored {
-                self.panic("Not supported yet: checked.Procedure_Symbol")
+                panic "Not supported yet: checked.Procedure_Symbol"
             }
             is nil {
             }
@@ -526,7 +526,7 @@ proc (^Checker).resolve_type(self, anon parsed_type: ^parsed.Type) -> ^checked.T
                     return type_symbol.type
                 }
                 is checked.Procedure_Symbol as _ignored {
-                    self.panic("Not supported yet: checked.Procedure_Symbol")
+                    panic "Not supported yet: checked.Procedure_Symbol"
                 }
                 is nil {
                 }
@@ -534,19 +534,19 @@ proc (^Checker).resolve_type(self, anon parsed_type: ^parsed.Type) -> ^checked.T
             raise self.error("Symbol is not a type")
         }
         is parsed.Multi_Pointer_Type as _ignored {
-            self.panic("Not supported yet: parsed.Multi_Pointer_Type")
+            panic "Not supported yet: parsed.Multi_Pointer_Type"
         }
         is parsed.Optional_Type as _ignored {
-            self.panic("Not supported yet: parsed.Optional_Type")
+            panic "Not supported yet: parsed.Optional_Type"
         }
         is parsed.Pointer_Type as _ignored {
-            self.panic("Not supported yet: parsed.Pointer_Type")
+            panic "Not supported yet: parsed.Pointer_Type"
         }
         is parsed.Procedure_Type as _ignored {
-            self.panic("Not supported yet: parsed.Procedure_Type")
+            panic "Not supported yet: parsed.Procedure_Type"
         }
         is parsed.Trait_Receiver_Type as _ignored {
-            self.panic("Not supported yet: parsed.Trait_Receiver_Type")
+            panic "Not supported yet: parsed.Trait_Receiver_Type"
         }
         is nil {
         }
@@ -562,15 +562,10 @@ proc (^Checker).error(self, anon message: str) -> error.Error {
     )
 }
 
-proc (^Checker).panic(self, anon message: str) {
-    libc.stderr.write("compiler/checker: \e[0;91mPanic!\e[0m ").write(message).end_line()
-    libc.exit(1)
-}
-
 proc (^Checker).allocate(self, size: usize, alignment: usize) -> ^Any {
     return try allocator.alloc(size: size, alignment: alignment) else {
-        self.panic(error.message)
-        yield null
+        libc.stderr.write(error.message).end_line()
+        panic "Allocation failed"
     }
 }
 

--- a/code/compiler/ir/instructions.code
+++ b/code/compiler/ir/instructions.code
@@ -2,8 +2,14 @@ import collections
 import compiler.lexer
 
 type Instruction = variant {
+    Call_Instruction
     Const_Instruction
     Ret_Instruction
+}
+
+type Call_Instruction = struct {
+    result: ^Value
+    callee: ^Procedure
 }
 
 type Const_Instruction = struct {

--- a/code/compiler/ir/instructions.code
+++ b/code/compiler/ir/instructions.code
@@ -8,12 +8,12 @@ type Instruction = variant {
 }
 
 type Call_Instruction = struct {
-    result: ^Value
+    result: Value
     callee: ^Procedure
 }
 
 type Const_Instruction = struct {
-    result: ^Value
+    result: Value
     literal: lexer.Integer
 }
 

--- a/code/compiler/ir/ir.code
+++ b/code/compiler/ir/ir.code
@@ -17,7 +17,11 @@ type Block = struct {
 }
 
 type Type = variant {
+    Nothing_Type
     Primitive_Type
+}
+
+type Nothing_Type = struct {
 }
 
 type Primitive_Type = struct {

--- a/code/compiler/lexer/match/match.code
+++ b/code/compiler/lexer/match/match.code
@@ -83,37 +83,37 @@ type No_Match = struct {
 proc (^Match).check(self, lexer: ^lexer.Lexer, at index: usize) -> bool !> No_Match {
     let token = lexer.peek_token(offset: index)
     switch self {
-        is Character {
+        is ^Character {
             if token is lexer.Character {
                 return true
             }
         }
-        is Comment {
+        is ^Comment {
             if token is lexer.Comment {
                 return true
             }
         }
-        is End_Of_File {
+        is ^End_Of_File {
             if token is lexer.End_Of_File {
                 return true
             }
         }
-        is End_Of_Line {
+        is ^End_Of_Line {
             if token is lexer.End_Of_Line or token is lexer.End_Of_File {
                 return true
             }
         }
-        is Identifier {
+        is ^Identifier {
             if token is lexer.Identifier {
                 return true
             }
         }
-        is Integer {
+        is ^Integer {
             if token is lexer.Integer {
                 return true
             }
         }
-        is Integer_Type {
+        is ^Integer_Type {
             if token is lexer.Identifier as identifier {
                 let lexeme = identifier.lexeme
                 if lexeme.char_at(0) == 'i' and (lexeme.equals("i8") or lexeme.equals("i16") or lexeme.equals("i32") or lexeme.equals("i64") or lexeme.equals("isize")) {
@@ -124,33 +124,33 @@ proc (^Match).check(self, lexer: ^lexer.Lexer, at index: usize) -> bool !> No_Ma
                 }
             }
         }
-        is Keyword as match {
+        is ^Keyword as match {
             if token is lexer.Identifier as identifier {
                 if identifier.lexeme.equals(match.lexeme) {
                     return true
                 }
             }
         }
-        is Other as other {
+        is ^Other as other {
             if token is lexer.Other as token_other {
                 if token_other.lexeme.char_at(0) == other.lexeme {
                     return true
                 }
             }
         }
-        is Space as match {
+        is ^Space as match {
             if not match.required {
                 return token is lexer.Space
             } else if token is lexer.Space {
                 return true
             }
         }
-        is String {
+        is ^String {
             if token is lexer.String {
                 return true
             }
         }
-        is nil {
+        is ^nil {
         }
     }
     raise No_Match()

--- a/code/compiler/lexer/tokens.code
+++ b/code/compiler/lexer/tokens.code
@@ -16,37 +16,37 @@ type Token = variant {
 
 proc (^Token).end_position(self) -> usize {
     switch self {
-        is Character as token {
+        is ^Character as token {
             return token.end_position()
         }
-        is Comment as token {
+        is ^Comment as token {
             return token.end_position()
         }
-        is End_Of_File as token {
+        is ^End_Of_File as token {
             return token.end_position()
         }
-        is End_Of_Line as token {
+        is ^End_Of_Line as token {
             return token.end_position()
         }
-        is Error as token {
+        is ^Error as token {
             return token.end_position()
         }
-        is Identifier as token {
+        is ^Identifier as token {
             return token.end_position()
         }
-        is Integer as token {
+        is ^Integer as token {
             return token.end_position()
         }
-        is Other as token {
+        is ^Other as token {
             return token.end_position()
         }
-        is Space as token {
+        is ^Space as token {
             return token.end_position()
         }
-        is String as token {
+        is ^String as token {
             return token.end_position()
         }
-        is nil {
+        is ^nil {
             return 0
         }
     }

--- a/code/compiler/lowerer/lowerer.code
+++ b/code/compiler/lowerer/lowerer.code
@@ -8,6 +8,7 @@ import string.builder
 
 type Lowerer = struct {
     program: ^ir.Program
+    package_name: str
     current_block: ^ir.Block
     next_value_id: usize
 }
@@ -15,17 +16,22 @@ type Lowerer = struct {
 proc lower(anon checked_package: ^checked.Package) -> ^ir.Program {
     let lowerer = Lowerer(
         program: null
+        package_name: checked_package.name
         current_block: null
         next_value_id: 0
     )
     lowerer.program = lowerer.allocate(size: type_size(ir.Program), alignment: type_alignment(ir.Program)).as(^ir.Program)
     lowerer.program.^ = ir.Program(procedures: collections.List<^ir.Procedure>())
 
+    let main_procedure: ^ir.Procedure = null
     let entry = checked_package.symbols.first
     while entry != null {
         switch entry.symbol {
             is checked.Procedure_Symbol as procedure_symbol {
-                lowerer.lower_procedure(procedure_symbol)
+                let procedure = lowerer.lower_procedure(procedure_symbol)
+                if procedure_symbol.name.equals("main") {
+                    main_procedure = procedure
+                }
             }
             is checked.Type_Symbol as _ignored {
             }
@@ -35,12 +41,19 @@ proc lower(anon checked_package: ^checked.Package) -> ^ir.Program {
         entry = entry.next
     }
 
+    if main_procedure != null {
+        lowerer.lower_main_wrapper(main_procedure)
+    }
+
     return lowerer.program
 }
 
-proc (^Lowerer).lower_procedure(self, anon procedure_symbol: checked.Procedure_Symbol) {
+proc (^Lowerer).lower_procedure(self, anon procedure_symbol: checked.Procedure_Symbol) -> ^ir.Procedure {
+    let name_builder = string.new_builder()
+    let name = name_builder.append(self.package_name).append_char('.').append(procedure_symbol.name).build()
+
     let procedure = self.alloc_procedure(ir.Procedure(
-        name: procedure_symbol.name
+        name: name
         parameters: collections.List<^ir.Value>()
         return_type: self.lower_type(procedure_symbol.procedure_type.return_type)
         blocks: collections.List<^ir.Block>()
@@ -48,7 +61,7 @@ proc (^Lowerer).lower_procedure(self, anon procedure_symbol: checked.Procedure_S
     self.program.procedures.append(value: procedure)
 
     if procedure_symbol.body == null {
-        return
+        return procedure
     }
 
     self.next_value_id = 0
@@ -60,6 +73,33 @@ proc (^Lowerer).lower_procedure(self, anon procedure_symbol: checked.Procedure_S
     self.current_block = block
 
     self.lower_statement(procedure_symbol.body)
+
+    return procedure
+}
+
+proc (^Lowerer).lower_main_wrapper(self, anon main_procedure: ^ir.Procedure) {
+    let wrapper = self.alloc_procedure(ir.Procedure(
+        name: "main"
+        parameters: collections.List<^ir.Value>()
+        return_type: main_procedure.return_type
+        blocks: collections.List<^ir.Block>()
+    ))
+    self.program.procedures.append(value: wrapper)
+
+    self.next_value_id = 0
+    let block = self.alloc_block(ir.Block(
+        label: 1
+        instructions: collections.List<^ir.Instruction>()
+    ))
+    wrapper.blocks.append(value: block)
+    self.current_block = block
+
+    let result: ^ir.Value = null
+    if main_procedure.return_type != null {
+        result = self.alloc_value(ir.Value(name: self.fresh_name(), type: main_procedure.return_type))
+    }
+    self.append_instruction(self.alloc_instruction(ir.Call_Instruction(result: result, callee: main_procedure)))
+    self.append_instruction(self.alloc_instruction(ir.Ret_Instruction(value: result)))
 }
 
 proc (^Lowerer).lower_statement(self, anon statement: ^checked.Statement) {

--- a/code/compiler/lowerer/lowerer.code
+++ b/code/compiler/lowerer/lowerer.code
@@ -27,15 +27,15 @@ proc lower(anon checked_package: ^checked.Package) -> ^ir.Program {
     let entry = checked_package.symbols.first
     while entry != null {
         switch entry.symbol {
-            is checked.Procedure_Symbol as procedure_symbol {
+            is ^checked.Procedure_Symbol as procedure_symbol {
                 let procedure = lowerer.lower_procedure(procedure_symbol)
                 if procedure_symbol.name.equals("main") {
                     main_procedure = procedure
                 }
             }
-            is checked.Type_Symbol as _ignored {
+            is ^checked.Type_Symbol {
             }
-            is nil {
+            is ^nil {
             }
         }
         entry = entry.next
@@ -48,7 +48,7 @@ proc lower(anon checked_package: ^checked.Package) -> ^ir.Program {
     return lowerer.program
 }
 
-proc (^Lowerer).lower_procedure(self, anon procedure_symbol: checked.Procedure_Symbol) -> ^ir.Procedure {
+proc (^Lowerer).lower_procedure(self, anon procedure_symbol: ^checked.Procedure_Symbol) -> ^ir.Procedure {
     let name_builder = string.new_builder()
     let name = name_builder.append(self.package_name).append_char('.').append(procedure_symbol.name).build()
 
@@ -104,28 +104,28 @@ proc (^Lowerer).lower_main_wrapper(self, anon main_procedure: ^ir.Procedure) {
 
 proc (^Lowerer).lower_statement(self, anon statement: ^checked.Statement) {
     switch statement {
-        is checked.Block_Statement as block_statement {
+        is ^checked.Block_Statement as block_statement {
             let item = block_statement.statements.first
             while item != null {
                 self.lower_statement(item.value)
                 item = item.next
             }
         }
-        is checked.Return_Statement as return_statement {
+        is ^checked.Return_Statement as return_statement {
             let value: ^ir.Value = null
             if return_statement.expression != null {
                 value = self.lower_expression(return_statement.expression)
             }
             self.append_instruction(self.alloc_instruction(ir.Ret_Instruction(value: value)))
         }
-        is nil {
+        is ^nil {
         }
     }
 }
 
 proc (^Lowerer).lower_expression(self, anon expression: ^checked.Expression) -> ^ir.Value {
     switch expression {
-        is checked.Integer_Expression as integer_expression {
+        is ^checked.Integer_Expression as integer_expression {
             let result = self.alloc_value(ir.Value(name: self.fresh_name(), type: self.lower_type(integer_expression.type)))
             let instruction = self.alloc_instruction(ir.Const_Instruction(
                 result: result
@@ -134,7 +134,7 @@ proc (^Lowerer).lower_expression(self, anon expression: ^checked.Expression) -> 
             self.append_instruction(instruction)
             return result
         }
-        is nil {
+        is ^nil {
         }
     }
     return null
@@ -145,13 +145,13 @@ proc (^Lowerer).lower_type(self, anon type: ^checked.Type) -> ^ir.Type {
         return null
     }
     switch type {
-        is checked.Builtin_Type as builtin_type {
+        is ^checked.Builtin_Type as builtin_type {
             return self.alloc_type(ir.Primitive_Type(name: builtin_type.name))
         }
-        is checked.Procedure_Type as _ignored {
+        is ^checked.Procedure_Type {
             panic "Lowering not supported yet: checked.Procedure_Type"
         }
-        is nil {
+        is ^nil {
         }
     }
     return null

--- a/code/compiler/lowerer/lowerer.code
+++ b/code/compiler/lowerer/lowerer.code
@@ -109,7 +109,7 @@ proc (^Lowerer).lower_type(self, anon type: ^checked.Type) -> ^ir.Type {
             return self.alloc_type(ir.Primitive_Type(name: builtin_type.name))
         }
         is checked.Procedure_Type as _ignored {
-            self.panic("Lowering not supported yet: checked.Procedure_Type")
+            panic "Lowering not supported yet: checked.Procedure_Type"
         }
         is nil {
         }
@@ -130,8 +130,8 @@ proc (^Lowerer).append_instruction(self, anon instruction: ^ir.Instruction) {
 
 proc (^Lowerer).allocate(self, size: usize, alignment: usize) -> ^Any {
     return try allocator.alloc(size: size, alignment: alignment) else {
-        self.panic(error.message)
-        yield null
+        libc.stderr.write(error.message).end_line()
+        panic "Allocation failed"
     }
 }
 
@@ -163,9 +163,4 @@ proc (^Lowerer).alloc_type(self, anon type: ir.Type) -> ^ir.Type {
     let typed_result = self.allocate(size: type_size(ir.Type), alignment: type_alignment(ir.Type)).as(^ir.Type)
     typed_result.^ = type
     return typed_result
-}
-
-proc (^Lowerer).panic(self, anon message: str) {
-    libc.stderr.write("Lowerer panic: ").write(message).end_line()
-    libc.exit(1)
 }

--- a/code/compiler/lowerer/lowerer.code
+++ b/code/compiler/lowerer/lowerer.code
@@ -94,11 +94,16 @@ proc (^Lowerer).lower_main_wrapper(self, anon main_procedure: ^ir.Procedure) {
     wrapper.blocks.append(value: block)
     self.current_block = block
 
+    let call_instruction = self.alloc_instruction(ir.Call_Instruction(
+        result: ir.Value(name: self.fresh_name(), type: main_procedure.return_type)
+        callee: main_procedure
+    ))
+    self.append_instruction(call_instruction)
+
     let result: ^ir.Value = null
-    if main_procedure.return_type != null {
-        result = self.alloc_value(ir.Value(name: self.fresh_name(), type: main_procedure.return_type))
+    if call_instruction is ^ir.Call_Instruction as instruction and main_procedure.return_type is not ^ir.Nothing_Type {
+        result = ^instruction.result
     }
-    self.append_instruction(self.alloc_instruction(ir.Call_Instruction(result: result, callee: main_procedure)))
     self.append_instruction(self.alloc_instruction(ir.Ret_Instruction(value: result)))
 }
 
@@ -126,13 +131,14 @@ proc (^Lowerer).lower_statement(self, anon statement: ^checked.Statement) {
 proc (^Lowerer).lower_expression(self, anon expression: ^checked.Expression) -> ^ir.Value {
     switch expression {
         is ^checked.Integer_Expression as integer_expression {
-            let result = self.alloc_value(ir.Value(name: self.fresh_name(), type: self.lower_type(integer_expression.type)))
             let instruction = self.alloc_instruction(ir.Const_Instruction(
-                result: result
+                result: ir.Value(name: self.fresh_name(), type: self.lower_type(integer_expression.type))
                 literal: integer_expression.token
             ))
             self.append_instruction(instruction)
-            return result
+            if instruction is ^ir.Const_Instruction as const_instruction {
+                return ^const_instruction.result
+            }
         }
         is ^nil {
         }
@@ -142,7 +148,7 @@ proc (^Lowerer).lower_expression(self, anon expression: ^checked.Expression) -> 
 
 proc (^Lowerer).lower_type(self, anon type: ^checked.Type) -> ^ir.Type {
     if type == null {
-        return null
+        return self.alloc_type(ir.Nothing_Type()) // TODO: There should be only one instance of ir.Nothing_Type
     }
     switch type {
         is ^checked.Builtin_Type as builtin_type {
@@ -154,7 +160,7 @@ proc (^Lowerer).lower_type(self, anon type: ^checked.Type) -> ^ir.Type {
         is ^nil {
         }
     }
-    return null
+    return self.alloc_type(ir.Nothing_Type())
 }
 
 proc (^Lowerer).fresh_name(self) -> str {
@@ -190,12 +196,6 @@ proc (^Lowerer).alloc_block(self, anon block: ir.Block) -> ^ir.Block {
 proc (^Lowerer).alloc_instruction(self, anon instruction: ir.Instruction) -> ^ir.Instruction {
     let typed_result = self.allocate(size: type_size(ir.Instruction), alignment: type_alignment(ir.Instruction)).as(^ir.Instruction)
     typed_result.^ = instruction
-    return typed_result
-}
-
-proc (^Lowerer).alloc_value(self, anon value: ir.Value) -> ^ir.Value {
-    let typed_result = self.allocate(size: type_size(ir.Value), alignment: type_alignment(ir.Value)).as(^ir.Value)
-    typed_result.^ = value
     return typed_result
 }
 

--- a/code/compiler/parser/parser.code
+++ b/code/compiler/parser/parser.code
@@ -1320,26 +1320,22 @@ proc (^Parser).parse_type_statement(self) -> ^parsed.Statement !> error.Error {
     ))
 }
 
-proc (^Parser).panic(self, anon message: str) {
-    libc.stderr.write("compiler/parser: \e[0;91mPanic!\e[0m ").write(message).end_line()
-    libc.exit(1)
-}
-
 proc (^Parser).register_type(self, anon statement: ^parsed.Statement) {
     let unwrapped = statement.^
     if unwrapped is parsed.Type_Statement as type_statement {
         let builder = string.new_builder()
         let absolute_name = builder.append(self.current_package.name).append_char('.').append(type_statement.name.lexeme).build()
         try self.types.put(key: absolute_name, value: statement) else {
-            self.panic(error.message)
+            libc.stderr.write(error.message).end_line()
+            panic "Failed to register type"
         }
     }
 }
 
 proc (^Parser).allocate(self, size: usize, alignment: usize) -> ^Any {
     return try allocator.alloc(size: size, alignment: alignment) else {
-        self.panic(error.message)
-        yield null
+        libc.stderr.write(error.message).end_line()
+        panic "Allocation failed"
     }
 }
 

--- a/code/compiler/printer/printer.code
+++ b/code/compiler/printer/printer.code
@@ -55,25 +55,25 @@ proc print_block(anon block: ^ir.Block, file: ^libc.FILE) {
 
 proc print_instruction(anon instruction: ^ir.Instruction, file: ^libc.FILE) {
     switch instruction {
-        is ir.Call_Instruction as call_instruction {
+        is ^ir.Call_Instruction as call_instruction {
             if call_instruction.result != null {
                 print_value_definition(call_instruction.result, file: file)
                 file.write(" = ")
             }
             file.write("call $").write(call_instruction.callee.name)
         }
-        is ir.Const_Instruction as const_instruction {
+        is ^ir.Const_Instruction as const_instruction {
             print_value_definition(const_instruction.result, file: file)
             file.write(" = const ").write(u64: const_instruction.literal.value)
         }
-        is ir.Ret_Instruction as ret_instruction {
+        is ^ir.Ret_Instruction as ret_instruction {
             file.write("ret")
             if ret_instruction.value != null {
                 file.write(char: ' ')
                 print_value_reference(ret_instruction.value, file: file)
             }
         }
-        is nil {
+        is ^nil {
         }
     }
 }
@@ -90,10 +90,10 @@ proc print_value_reference(anon value: ^ir.Value, file: ^libc.FILE) {
 
 proc print_type(anon type: ^ir.Type, file: ^libc.FILE) {
     switch type {
-        is ir.Primitive_Type as primitive_type {
+        is ^ir.Primitive_Type as primitive_type {
             file.write(primitive_type.name)
         }
-        is nil {
+        is ^nil {
         }
     }
 }

--- a/code/compiler/printer/printer.code
+++ b/code/compiler/printer/printer.code
@@ -55,6 +55,13 @@ proc print_block(anon block: ^ir.Block, file: ^libc.FILE) {
 
 proc print_instruction(anon instruction: ^ir.Instruction, file: ^libc.FILE) {
     switch instruction {
+        is ir.Call_Instruction as call_instruction {
+            if call_instruction.result != null {
+                print_value_definition(call_instruction.result, file: file)
+                file.write(" = ")
+            }
+            file.write("call $").write(call_instruction.callee.name)
+        }
         is ir.Const_Instruction as const_instruction {
             print_value_definition(const_instruction.result, file: file)
             file.write(" = const ").write(u64: const_instruction.literal.value)

--- a/code/compiler/printer/printer.code
+++ b/code/compiler/printer/printer.code
@@ -27,7 +27,7 @@ proc print_procedure(anon procedure: ^ir.Procedure, file: ^libc.FILE) {
         parameter_item = parameter_item.next
     }
     file.write(char: ')')
-    if procedure.return_type != null {
+    if procedure.return_type is not ^ir.Nothing_Type {
         file.write(": ")
         print_type(procedure.return_type, file: file)
     }
@@ -56,14 +56,14 @@ proc print_block(anon block: ^ir.Block, file: ^libc.FILE) {
 proc print_instruction(anon instruction: ^ir.Instruction, file: ^libc.FILE) {
     switch instruction {
         is ^ir.Call_Instruction as call_instruction {
-            if call_instruction.result != null {
-                print_value_definition(call_instruction.result, file: file)
+            if call_instruction.result.type is not ^ir.Nothing_Type {
+                print_value_definition(^call_instruction.result, file: file)
                 file.write(" = ")
             }
             file.write("call $").write(call_instruction.callee.name)
         }
         is ^ir.Const_Instruction as const_instruction {
-            print_value_definition(const_instruction.result, file: file)
+            print_value_definition(^const_instruction.result, file: file)
             file.write(" = const ").write(u64: const_instruction.literal.value)
         }
         is ^ir.Ret_Instruction as ret_instruction {
@@ -90,6 +90,9 @@ proc print_value_reference(anon value: ^ir.Value, file: ^libc.FILE) {
 
 proc print_type(anon type: ^ir.Type, file: ^libc.FILE) {
     switch type {
+        is ^ir.Nothing_Type {
+            panic
+        }
         is ^ir.Primitive_Type as primitive_type {
             file.write(primitive_type.name)
         }

--- a/compiler/Checked_Code.c
+++ b/compiler/Checked_Code.c
@@ -1057,6 +1057,7 @@ bool Checked_Statement__is_terminal(Checked_Statement *self) {
         Checked_Loop_Statement *loop_statement = (Checked_Loop_Statement *)self;
         return Checked_Statement__is_terminal(loop_statement->body_statement);
     }
+    case CHECKED_STATEMENT_KIND__PANIC:
     case CHECKED_STATEMENT_KIND__RAISE:
     case CHECKED_STATEMENT_KIND__RETURN:
         return true;
@@ -1122,6 +1123,12 @@ Checked_If_Statement *Checked_If_Statement__create(Source_Location location, Che
 Checked_Loop_Statement *Checked_Loop_Statement__create(Source_Location location, Checked_Statement *body_statement) {
     Checked_Loop_Statement *statement = (Checked_Loop_Statement *)Checked_Statement__create_kind(CHECKED_STATEMENT_KIND__LOOP, sizeof(Checked_Loop_Statement), location);
     statement->body_statement = body_statement;
+    return statement;
+}
+
+Checked_Panic_Statement *Checked_Panic_Statement__create(Source_Location location, String *message) {
+    Checked_Panic_Statement *statement = (Checked_Panic_Statement *)Checked_Statement__create_kind(CHECKED_STATEMENT_KIND__PANIC, sizeof(Checked_Panic_Statement), location);
+    statement->message = message;
     return statement;
 }
 

--- a/compiler/Checked_Code.c
+++ b/compiler/Checked_Code.c
@@ -608,9 +608,10 @@ Checked_Variable_Symbol *Checked_Variable_Symbol__create(Checked_Package *packag
     return variable;
 }
 
-Checked_Variant_Alias_Symbol *Checked_Variant_Alias_Symbol__create(Checked_Package *package, Source_Location location, String *name, Checked_Type *type, bool is_mutable) {
+Checked_Variant_Alias_Symbol *Checked_Variant_Alias_Symbol__create(Checked_Package *package, Source_Location location, String *name, Checked_Type *type, bool is_mutable, bool by_pointer) {
     Checked_Variant_Alias_Symbol *symbol = (Checked_Variant_Alias_Symbol *)Checked_Symbol__create_kind(CHECKED_SYMBOL_KIND__VARIANT_ALIAS, sizeof(Checked_Variant_Alias_Symbol), package, location, name, type, false);
     symbol->is_mutable = is_mutable;
+    symbol->by_pointer = by_pointer;
     return symbol;
 }
 

--- a/compiler/Checked_Code.h
+++ b/compiler/Checked_Code.h
@@ -379,6 +379,7 @@ typedef enum Checked_Statement_Kind {
     CHECKED_STATEMENT_KIND__EXPRESSION,
     CHECKED_STATEMENT_KIND__IF,
     CHECKED_STATEMENT_KIND__LOOP,
+    CHECKED_STATEMENT_KIND__PANIC,
     CHECKED_STATEMENT_KIND__RAISE,
     CHECKED_STATEMENT_KIND__RETURN,
     CHECKED_STATEMENT_KIND__VARIABLE,
@@ -906,6 +907,13 @@ typedef struct Checked_Loop_Statement {
 } Checked_Loop_Statement;
 
 Checked_Loop_Statement *Checked_Loop_Statement__create(Source_Location location, Checked_Statement *body_statement);
+
+typedef struct Checked_Panic_Statement {
+    Checked_Statement super;
+    String *message;
+} Checked_Panic_Statement;
+
+Checked_Panic_Statement *Checked_Panic_Statement__create(Source_Location location, String *message);
 
 typedef struct Checked_Raise_Statement {
     Checked_Statement super;

--- a/compiler/Checked_Code.h
+++ b/compiler/Checked_Code.h
@@ -469,9 +469,10 @@ Checked_Variable_Symbol *Checked_Variable_Symbol__create(Checked_Package *packag
 typedef struct Checked_Variant_Alias_Symbol {
     Checked_Symbol super;
     bool is_mutable;
+    bool by_pointer;
 } Checked_Variant_Alias_Symbol;
 
-Checked_Variant_Alias_Symbol *Checked_Variant_Alias_Symbol__create(Checked_Package *package, Source_Location location, String *name, Checked_Type *type, bool is_mutable);
+Checked_Variant_Alias_Symbol *Checked_Variant_Alias_Symbol__create(Checked_Package *package, Source_Location location, String *name, Checked_Type *type, bool is_mutable, bool by_pointer);
 
 typedef struct Checked_Symbols {
     struct Checked_Symbols *parent;

--- a/compiler/Checker.c
+++ b/compiler/Checker.c
@@ -1286,17 +1286,46 @@ Checked_Expression *Checker__check_integer_expression(Checker *self, Checker_Con
     return (Checked_Expression *)Checked_Integer_Expression__create(parsed_expression->super.super.location, expression_type, expression_value, expression_base, parsed_expression->super.literal);
 }
 
+Checked_Type *Checker__resolve_match_case_type(Checker *self, Checker_Context *context, Parsed_Type *parsed_type, bool through_pointer, Checked_Type **alias_type, bool *by_pointer) {
+    Checked_Type *runtime_type = Checker__resolve_type(self, context, parsed_type);
+    *alias_type = runtime_type;
+    *by_pointer = false;
+    if (through_pointer) {
+        if (runtime_type->kind != CHECKED_TYPE_KIND__POINTER) {
+            pWriter__begin_location_message(stderr_writer, parsed_type->location, WRITER_STYLE__ERROR);
+            pWriter__write__cstring(stderr_writer, "A pointer-to-variant case must be a pointer type, such as ^");
+            pWriter__write__checked_type(stderr_writer, runtime_type);
+            pWriter__end_location_message(stderr_writer);
+            panic();
+        }
+        *by_pointer = true;
+        return ((Checked_Pointer_Type *)runtime_type)->other_type;
+    }
+    return runtime_type;
+}
+
 Checked_Expression *Checker__check_is_expression(Checker *self, Checker_Context *context, Parsed_Is_Expression *parsed_expression) {
     Checked_Expression *value_expression = Checker__check_expression(self, context, parsed_expression->value_expression, NULL);
     Checked_Type *value_type = value_expression->type;
-    Checked_Type *runtime_type = Checker__resolve_type(self, context, parsed_expression->runtime_type);
-    switch (value_type->kind) {
+    Checked_Type *matched_type = value_type;
+    bool through_pointer = false;
+    if (value_type->kind == CHECKED_TYPE_KIND__POINTER) {
+        Checked_Type *pointed_type = ((Checked_Pointer_Type *)value_type)->other_type;
+        if (pointed_type->kind == CHECKED_TYPE_KIND__OPTIONAL || pointed_type->kind == CHECKED_TYPE_KIND__VARIANT) {
+            matched_type = pointed_type;
+            through_pointer = true;
+        }
+    }
+    Checked_Type *alias_type;
+    bool case_by_pointer;
+    Checked_Type *case_type = Checker__resolve_match_case_type(self, context, parsed_expression->runtime_type, through_pointer, &alias_type, &case_by_pointer);
+    switch (matched_type->kind) {
     case CHECKED_TYPE_KIND__OPTIONAL:
     case CHECKED_TYPE_KIND__VARIANT: {
-        Checked_Variant_Type *variant_type = (Checked_Variant_Type *)value_type;
+        Checked_Variant_Type *variant_type = (Checked_Variant_Type *)matched_type;
         Checked_Variant_Case *variant_case = variant_type->first_variant_case;
         for (; variant_case != NULL; variant_case = variant_case->next_variant) {
-            if (Checked_Type__equals(variant_case->type, runtime_type)) {
+            if (Checked_Type__equals(variant_case->type, case_type)) {
                 Checked_Variant_Alias_Symbol *alias_symbol = NULL;
                 if (parsed_expression->alias != NULL) {
                     if (parsed_expression->is_not) {
@@ -1311,19 +1340,22 @@ Checked_Expression *Checker__check_is_expression(Checker *self, Checker_Context 
                         pWriter__end_location_message(stderr_writer);
                         panic();
                     }
-                    switch (value_expression->kind) {
-                    case CHECKED_EXPRESSION_KIND__ARRAY_ACCESS:
-                    case CHECKED_EXPRESSION_KIND__DEREFERENCE:
-                    case CHECKED_EXPRESSION_KIND__MEMBER_ACCESS:
-                    case CHECKED_EXPRESSION_KIND__SYMBOL:
-                        break;
-                    default:
-                        pWriter__begin_location_message(stderr_writer, value_expression->location, WRITER_STYLE__ERROR);
-                        pWriter__write__cstring(stderr_writer, "Variant aliases require an addressable expression");
-                        pWriter__end_location_message(stderr_writer);
-                        panic();
+                    if (!through_pointer) {
+                        switch (value_expression->kind) {
+                        case CHECKED_EXPRESSION_KIND__ARRAY_ACCESS:
+                        case CHECKED_EXPRESSION_KIND__DEREFERENCE:
+                        case CHECKED_EXPRESSION_KIND__MEMBER_ACCESS:
+                        case CHECKED_EXPRESSION_KIND__SYMBOL:
+                            break;
+                        default:
+                            pWriter__begin_location_message(stderr_writer, value_expression->location, WRITER_STYLE__ERROR);
+                            pWriter__write__cstring(stderr_writer, "Variant aliases require an addressable expression");
+                            pWriter__end_location_message(stderr_writer);
+                            panic();
+                        }
                     }
-                    alias_symbol = Checked_Variant_Alias_Symbol__create(context->checked_package, parsed_expression->alias->super.location, parsed_expression->alias->super.lexeme, variant_case->type, Checked_Expression__is_mutable(value_expression));
+                    bool alias_is_mutable = case_by_pointer ? false : Checked_Expression__is_mutable(value_expression);
+                    alias_symbol = Checked_Variant_Alias_Symbol__create(context->checked_package, parsed_expression->alias->super.location, parsed_expression->alias->super.lexeme, alias_type, alias_is_mutable, case_by_pointer);
                     Checked_Symbols__append_symbol(self->symbols, (Checked_Symbol *)alias_symbol);
                 }
                 return (Checked_Expression *)Checked_Is_Variant_Case_Expression__create(parsed_expression->super.location, (Checked_Type *)self->builtin_types->bool_type, value_expression, variant_case, alias_symbol, parsed_expression->is_not);
@@ -1333,7 +1365,7 @@ Checked_Expression *Checker__check_is_expression(Checker *self, Checker_Context 
         pWriter__write__cstring(stderr_writer, value_type->kind == CHECKED_TYPE_KIND__OPTIONAL ? "Optional type " : "Variant type ");
         pWriter__write__checked_type(stderr_writer, value_type);
         pWriter__write__cstring(stderr_writer, " doesn't have ");
-        pWriter__write__checked_type(stderr_writer, runtime_type);
+        pWriter__write__checked_type(stderr_writer, case_type);
         pWriter__write__cstring(stderr_writer, " case");
         pWriter__end_location_message(stderr_writer);
         panic();
@@ -2515,17 +2547,17 @@ Checked_Statement *Checker__check_return_statement(Checker *self, Checker_Contex
     return (Checked_Statement *)Checked_Return_Statement__create(parsed_statement->super.location, result_expression);
 }
 
-Checked_Variant_Switch_Statement *Checker__check_variant_switch_statement(Checker *self, Checker_Context *context, Parsed_Switch_Statement *parsed_statement, Checked_Expression *variant_expression, Checked_Variant_Type *variant_type);
+Checked_Variant_Switch_Statement *Checker__check_variant_switch_statement(Checker *self, Checker_Context *context, Parsed_Switch_Statement *parsed_statement, Checked_Expression *variant_expression, Checked_Variant_Type *variant_type, bool through_pointer);
 
 Checked_Statement *Checker__check_switch_statement(Checker *self, Checker_Context *context, Parsed_Switch_Statement *parsed_statement) {
     Checked_Expression *expression = Checker__check_expression(self, context, parsed_statement->expression, NULL);
     if (expression->type->kind == CHECKED_TYPE_KIND__OPTIONAL || expression->type->kind == CHECKED_TYPE_KIND__VARIANT) {
-        return (Checked_Statement *)Checker__check_variant_switch_statement(self, context, parsed_statement, expression, (Checked_Variant_Type *)expression->type);
+        return (Checked_Statement *)Checker__check_variant_switch_statement(self, context, parsed_statement, expression, (Checked_Variant_Type *)expression->type, false);
     }
     if (expression->type->kind == CHECKED_TYPE_KIND__POINTER) {
         Checked_Type *pointed_type = ((Checked_Pointer_Type *)expression->type)->other_type;
         if (pointed_type->kind == CHECKED_TYPE_KIND__OPTIONAL || pointed_type->kind == CHECKED_TYPE_KIND__VARIANT) {
-            return (Checked_Statement *)Checker__check_variant_switch_statement(self, context, parsed_statement, expression, (Checked_Variant_Type *)pointed_type);
+            return (Checked_Statement *)Checker__check_variant_switch_statement(self, context, parsed_statement, expression, (Checked_Variant_Type *)pointed_type, true);
         }
     }
     pWriter__begin_location_message(stderr_writer, expression->location, WRITER_STYLE__ERROR);
@@ -2536,7 +2568,7 @@ Checked_Statement *Checker__check_switch_statement(Checker *self, Checker_Contex
     panic();
 }
 
-Checked_Variant_Switch_Statement *Checker__check_variant_switch_statement(Checker *self, Checker_Context *context, Parsed_Switch_Statement *parsed_statement, Checked_Expression *variant_expression, Checked_Variant_Type *variant_type) {
+Checked_Variant_Switch_Statement *Checker__check_variant_switch_statement(Checker *self, Checker_Context *context, Parsed_Switch_Statement *parsed_statement, Checked_Expression *variant_expression, Checked_Variant_Type *variant_type, bool through_pointer) {
     bool *variants_with_case = malloc(variant_type->variant_count * sizeof(bool));
     Parsed_Switch_Case *parsed_switch_case = parsed_statement->first_case;
     Checked_Variant_Switch_Case *first_variant_switch_case = NULL;
@@ -2561,7 +2593,9 @@ Checked_Variant_Switch_Statement *Checker__check_variant_switch_statement(Checke
                 pWriter__end_location_message(stderr_writer);
                 panic();
             }
-            Checked_Type *variant_case_type = Checker__resolve_type(self, context, parsed_switch_case->variant.type);
+            Checked_Type *alias_type;
+            bool case_by_pointer;
+            Checked_Type *variant_case_type = Checker__resolve_match_case_type(self, context, parsed_switch_case->variant.type, through_pointer, &alias_type, &case_by_pointer);
             Checked_Variant_Case *variant_case = variant_type->first_variant_case;
             for (; variant_case != NULL; variant_case = variant_case->next_variant) {
                 if (Checked_Type__equals(variant_case->type, variant_case_type)) {
@@ -2591,7 +2625,8 @@ Checked_Variant_Switch_Statement *Checker__check_variant_switch_statement(Checke
             Checked_Variant_Alias_Symbol *alias_symbol = NULL;
             if (parsed_switch_case->variant.alias != NULL) {
                 // Create a symbol for the variant case
-                alias_symbol = Checked_Variant_Alias_Symbol__create(context->checked_package, parsed_switch_case->variant.alias->super.location, parsed_switch_case->variant.alias->super.lexeme, variant_case->type, Checked_Expression__is_mutable(variant_expression));
+                bool alias_is_mutable = case_by_pointer ? false : Checked_Expression__is_mutable(variant_expression);
+                alias_symbol = Checked_Variant_Alias_Symbol__create(context->checked_package, parsed_switch_case->variant.alias->super.location, parsed_switch_case->variant.alias->super.lexeme, alias_type, alias_is_mutable, case_by_pointer);
                 Checked_Symbols__append_symbol(self->symbols, (Checked_Symbol *)alias_symbol);
             }
 

--- a/compiler/Checker.c
+++ b/compiler/Checker.c
@@ -2458,6 +2458,11 @@ Checked_Statement *Checker__check_loop_statement(Checker *self, Checker_Context 
     return (Checked_Statement *)loop_statement;
 }
 
+Checked_Statement *Checker__check_panic_statement(Checker *self, Checker_Context *context, Parsed_Panic_Statement *parsed_statement) {
+    context->is_unreachable_statement = true;
+    return (Checked_Statement *)Checked_Panic_Statement__create(parsed_statement->super.location, parsed_statement->message != NULL ? parsed_statement->message->value : NULL);
+}
+
 Checked_Statement *Checker__check_raise_statement(Checker *self, Checker_Context *context, Parsed_Raise_Statement *parsed_statement) {
     if (context->return_type->kind != CHECKED_TYPE_KIND__RESULT) {
         pWriter__begin_location_message(stderr_writer, parsed_statement->super.location, WRITER_STYLE__ERROR);
@@ -2868,6 +2873,8 @@ Checked_Statement *Checker__check_statement(Checker *self, Checker_Context *cont
         return Checker__check_if_statement(self, context, (Parsed_If_Statement *)parsed_statement);
     case PARSED_STATEMENT_KIND__LOOP:
         return Checker__check_loop_statement(self, context, (Parsed_Loop_Statement *)parsed_statement);
+    case PARSED_STATEMENT_KIND__PANIC:
+        return Checker__check_panic_statement(self, context, (Parsed_Panic_Statement *)parsed_statement);
     case PARSED_STATEMENT_KIND__RAISE:
         return Checker__check_raise_statement(self, context, (Parsed_Raise_Statement *)parsed_statement);
     case PARSED_STATEMENT_KIND__RETURN:

--- a/compiler/Lowerer.c
+++ b/compiler/Lowerer.c
@@ -403,6 +403,13 @@ IR_Value *Lowerer__lower_variant_case_pointer(Lowerer *self, IR_Value *variant_p
 
 void Lowerer__bind_variant_alias(Lowerer *self, Checked_Variant_Alias_Symbol *alias_symbol, IR_Value *variant_pointer, Checked_Variant_Case *variant_case) {
     IR_Value *case_pointer = Lowerer__lower_variant_case_pointer(self, variant_pointer, variant_case);
+    if (alias_symbol->by_pointer) {
+        IR_Variable *variable = Lowerer__declare_variable(self, (Checked_Symbol *)alias_symbol, case_pointer->type);
+        case_pointer->name = String__create_copy(variable->super.value.name);
+        case_pointer->variable = variable;
+        IR_Value_List__append(&self->scope, case_pointer);
+        return;
+    }
     IR_Variable *variable = Lowerer__declare_variable(self, (Checked_Symbol *)alias_symbol, ((IR_Pointer_Type *)case_pointer->type)->pointee);
     String *pointer_name = String__create_copy(variable->super.value.name);
     String__append_cstring(pointer_name, ".ptr");
@@ -976,6 +983,9 @@ IR_Value *Lowerer__lower_expression(Lowerer *self, Checked_Expression *expressio
         }
         if (symbol->kind == CHECKED_SYMBOL_KIND__VARIANT_ALIAS) {
             IR_Value *value_pointer = Lowerer__find_scope(self, symbol);
+            if (((Checked_Variant_Alias_Symbol *)symbol)->by_pointer) {
+                return value_pointer;
+            }
             IR_Variable *variable = value_pointer->variable;
             variable->version++;
             String *result_name = String__create_copy(variable->super.value.name);

--- a/compiler/Lowerer.c
+++ b/compiler/Lowerer.c
@@ -392,11 +392,15 @@ IR_Value *Lowerer__lower_variant_tag(Lowerer *self, IR_Value *variant_pointer) {
 
 IR_Value *Lowerer__lower_variant_case_pointer(Lowerer *self, IR_Value *variant_pointer, Checked_Variant_Case *variant_case) {
     IR_Struct_Type *variant_struct_type = (IR_Struct_Type *)((IR_Pointer_Type *)variant_pointer->type)->pointee;
-    IR_Type *value_field_type = variant_struct_type->first_field->next_field->type;
-    IR_Struct_Offset_Instruction *value_offset = IR_Struct_Offset_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(value_field_type), variant_pointer, String__create_from("value"));
-    IR_Block__append_instruction(self->block, (IR_Instruction *)value_offset);
+    IR_Value *value_pointer = variant_pointer;
+    if (variant_struct_type->first_field->next_field != NULL) {
+        IR_Type *value_field_type = variant_struct_type->first_field->next_field->type;
+        IR_Struct_Offset_Instruction *value_offset = IR_Struct_Offset_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(value_field_type), variant_pointer, String__create_from("value"));
+        IR_Block__append_instruction(self->block, (IR_Instruction *)value_offset);
+        value_pointer = &value_offset->super.result;
+    }
     IR_Type *case_type = Lowerer__lower_type(self, variant_case->type);
-    IR_Cast_Instruction *cast = IR_Cast_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(case_type), &value_offset->super.result);
+    IR_Cast_Instruction *cast = IR_Cast_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(case_type), value_pointer);
     IR_Block__append_instruction(self->block, (IR_Instruction *)cast);
     return &cast->super.result;
 }
@@ -679,7 +683,6 @@ IR_Value *Lowerer__lower_expression(Lowerer *self, Checked_Expression *expressio
         IR_Type *variant_type = Lowerer__lower_type(self, expression->type);
         IR_Struct_Type *variant_struct_type = (IR_Struct_Type *)variant_type;
         IR_Type *tag_type = variant_struct_type->first_field->type;
-        IR_Type *value_field_type = variant_struct_type->first_field->next_field->type;
 
         self->value_counter++;
         String *temporary_name = String__create();
@@ -694,13 +697,16 @@ IR_Value *Lowerer__lower_expression(Lowerer *self, Checked_Expression *expressio
         IR_Block__append_instruction(self->block, (IR_Instruction *)IR_Store_Instruction__create(&tag_offset->super.result, &tag->super.result));
 
         if (make_variant_expression->variant_case->type->kind != CHECKED_TYPE_KIND__NIL) {
-            IR_Value *payload = Lowerer__lower_expression(self, make_variant_expression->expression);
             IR_Type *payload_type = Lowerer__lower_type(self, make_variant_expression->expression->type);
-            IR_Struct_Offset_Instruction *value_offset = IR_Struct_Offset_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(value_field_type), &alloc->super.result, String__create_from("value"));
-            IR_Block__append_instruction(self->block, (IR_Instruction *)value_offset);
-            IR_Cast_Instruction *cast = IR_Cast_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(payload_type), &value_offset->super.result);
-            IR_Block__append_instruction(self->block, (IR_Instruction *)cast);
-            IR_Block__append_instruction(self->block, (IR_Instruction *)IR_Store_Instruction__create(&cast->super.result, payload));
+            if (IR_Type__size(payload_type) > 0) {
+                IR_Type *value_field_type = variant_struct_type->first_field->next_field->type;
+                IR_Value *payload = Lowerer__lower_expression(self, make_variant_expression->expression);
+                IR_Struct_Offset_Instruction *value_offset = IR_Struct_Offset_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(value_field_type), &alloc->super.result, String__create_from("value"));
+                IR_Block__append_instruction(self->block, (IR_Instruction *)value_offset);
+                IR_Cast_Instruction *cast = IR_Cast_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(payload_type), &value_offset->super.result);
+                IR_Block__append_instruction(self->block, (IR_Instruction *)cast);
+                IR_Block__append_instruction(self->block, (IR_Instruction *)IR_Store_Instruction__create(&cast->super.result, payload));
+            }
         }
 
         IR_Load_Instruction *load = IR_Load_Instruction__create(Lowerer__fresh_name(self), variant_type, &alloc->super.result);

--- a/compiler/Lowerer.c
+++ b/compiler/Lowerer.c
@@ -469,6 +469,20 @@ IR_Value *Lowerer__build_result(Lowerer *self, IR_Type *result_type, bool succes
     return &load->super.result;
 }
 
+IR_Value *Lowerer__string_global(Lowerer *self, String *value) {
+    for (IR_Global *global = self->program->first_global; global != NULL; global = global->next_global) {
+        if (global->literal != NULL && String__equals_string(global->literal, value)) {
+            return &global->super.value;
+        }
+    }
+    self->string_counter++;
+    String *global_name = String__create_from("str_");
+    String__append_int16_t(global_name, self->string_counter);
+    IR_Global *global = IR_String_Global__create(global_name, (IR_Type *)IR_Multi_Pointer_Type__create(IR_Type__get(IR_TYPE_KIND__U8)), value);
+    IR_Program__append_global(self->program, global);
+    return &global->super.value;
+}
+
 IR_Value *Lowerer__lower_expression(Lowerer *self, Checked_Expression *expression) {
     switch (expression->kind) {
     case CHECKED_EXPRESSION_KIND__CALL: {
@@ -708,21 +722,7 @@ IR_Value *Lowerer__lower_expression(Lowerer *self, Checked_Expression *expressio
             IR_Block__append_instruction(self->block, (IR_Instruction *)null);
             data = &null->super.result;
         } else {
-            data = NULL;
-            for (IR_Global *global = self->program->first_global; global != NULL; global = global->next_global) {
-                if (global->literal != NULL && String__equals_string(global->literal, string_expression->value)) {
-                    data = &global->super.value;
-                    break;
-                }
-            }
-            if (data == NULL) {
-                self->string_counter++;
-                String *global_name = String__create_from("str_");
-                String__append_int16_t(global_name, self->string_counter);
-                IR_Global *global = IR_String_Global__create(global_name, Lowerer__lower_type(self, data_member->type), string_expression->value);
-                IR_Program__append_global(self->program, global);
-                data = &global->super.value;
-            }
+            data = Lowerer__string_global(self, string_expression->value);
         }
 
         IR_Const_Instruction *length = IR_Const_Instruction__create(Lowerer__fresh_name(self), Lowerer__lower_type(self, length_member->type), string_expression->value->length, NULL);
@@ -860,6 +860,9 @@ IR_Value *Lowerer__lower_expression(Lowerer *self, Checked_Expression *expressio
         IR_Value *else_value = Lowerer__lower_expression(self, try_expression->else_expression);
         IR_Block *else_end_block = self->block;
         bool else_terminated = IR_Block__is_terminated(self->block);
+        if (!else_terminated && try_expression->else_expression->kind == CHECKED_EXPRESSION_KIND__BLOCK) {
+            else_terminated = Checked_Statement__is_terminal(((Checked_Block_Expression *)try_expression->else_expression)->block_statement);
+        }
         if (!else_terminated) {
             IR_Block__append_instruction(self->block, (IR_Instruction *)IR_Jmp_Instruction__create(end_block));
         }
@@ -1094,6 +1097,50 @@ void Lowerer__lower_statement(Lowerer *self, Checked_Statement *statement) {
         }
         IR_Procedure__append_block(self->procedure, end_block);
         self->block = end_block;
+        break;
+    }
+    case CHECKED_STATEMENT_KIND__PANIC: {
+        Checked_Panic_Statement *panic_statement = (Checked_Panic_Statement *)statement;
+
+        String *message = String__create();
+        Writer writer = String__create_writer(message);
+        pWriter__write__string(&writer, statement->location.source->file_path);
+        pWriter__write__char(&writer, ':');
+        pWriter__write__uint64(&writer, statement->location.start_line);
+        pWriter__write__cstring(&writer, ": Panic!");
+        if (panic_statement->message != NULL) {
+            pWriter__write__char(&writer, ' ');
+            pWriter__write__string(&writer, panic_statement->message);
+        }
+        pWriter__end_line(&writer);
+
+        IR_Value *data = Lowerer__string_global(self, message);
+        IR_Cast_Instruction *buffer = IR_Cast_Instruction__create(Lowerer__fresh_name(self), (IR_Type *)IR_Pointer_Type__create(IR_Type__get(IR_TYPE_KIND__ANY)), data);
+        IR_Block__append_instruction(self->block, (IR_Instruction *)buffer);
+        IR_Const_Instruction *size = IR_Const_Instruction__create(Lowerer__fresh_name(self), IR_Type__get(IR_TYPE_KIND__USIZE), 1, NULL);
+        IR_Block__append_instruction(self->block, (IR_Instruction *)size);
+        IR_Const_Instruction *count = IR_Const_Instruction__create(Lowerer__fresh_name(self), IR_Type__get(IR_TYPE_KIND__USIZE), message->length, NULL);
+        IR_Block__append_instruction(self->block, (IR_Instruction *)count);
+        IR_Value *stderr_global = Lowerer__find_global(self, String__create_from("stderr"));
+        IR_Load_Instruction *file = IR_Load_Instruction__create(Lowerer__fresh_name(self), ((IR_Pointer_Type *)stderr_global->type)->pointee, stderr_global);
+        IR_Block__append_instruction(self->block, (IR_Instruction *)file);
+
+        IR_Value *fwrite_callee = Lowerer__find_global(self, String__create_from("fwrite"));
+        IR_Type *fwrite_return_type = ((IR_Procedure_Type *)((IR_Pointer_Type *)fwrite_callee->type)->pointee)->return_type;
+        IR_Call_Instruction *fwrite_call = IR_Call_Instruction__create(fwrite_return_type->kind != IR_TYPE_KIND__NOTHING ? Lowerer__fresh_name(self) : NULL, fwrite_return_type, fwrite_callee);
+        IR_Value_List__append(&fwrite_call->super.operands, &buffer->super.result);
+        IR_Value_List__append(&fwrite_call->super.operands, &size->super.result);
+        IR_Value_List__append(&fwrite_call->super.operands, &count->super.result);
+        IR_Value_List__append(&fwrite_call->super.operands, &file->super.result);
+        IR_Block__append_instruction(self->block, (IR_Instruction *)fwrite_call);
+
+        IR_Const_Instruction *status = IR_Const_Instruction__create(Lowerer__fresh_name(self), IR_Type__get(IR_TYPE_KIND__I32), 1, NULL);
+        IR_Block__append_instruction(self->block, (IR_Instruction *)status);
+        IR_Value *exit_callee = Lowerer__find_global(self, String__create_from("exit"));
+        IR_Type *exit_return_type = ((IR_Procedure_Type *)((IR_Pointer_Type *)exit_callee->type)->pointee)->return_type;
+        IR_Call_Instruction *exit_call = IR_Call_Instruction__create(exit_return_type->kind != IR_TYPE_KIND__NOTHING ? Lowerer__fresh_name(self) : NULL, exit_return_type, exit_callee);
+        IR_Value_List__append(&exit_call->super.operands, &status->super.result);
+        IR_Block__append_instruction(self->block, (IR_Instruction *)exit_call);
         break;
     }
     case CHECKED_STATEMENT_KIND__RAISE: {

--- a/compiler/Parsed_Code.c
+++ b/compiler/Parsed_Code.c
@@ -381,6 +381,12 @@ Parsed_Statement *Parsed_Loop_Statement__create(Source_Location location, Parsed
     return (Parsed_Statement *)statement;
 }
 
+Parsed_Statement *Parsed_Panic_Statement__create(Source_Location location, String_Token *message) {
+    Parsed_Panic_Statement *statement = (Parsed_Panic_Statement *)Parsed_Statement__create_kind(PARSED_STATEMENT_KIND__PANIC, sizeof(Parsed_Panic_Statement), location);
+    statement->message = message;
+    return (Parsed_Statement *)statement;
+}
+
 Parsed_Raise_Statement *Parsed_Raise_Statement__create(Source_Location location, Parsed_Expression *expression) {
     Parsed_Raise_Statement *statement = (Parsed_Raise_Statement *)Parsed_Statement__create_kind(PARSED_STATEMENT_KIND__RAISE, sizeof(Parsed_Raise_Statement), location);
     statement->expression = expression;

--- a/compiler/Parsed_Code.h
+++ b/compiler/Parsed_Code.h
@@ -414,6 +414,7 @@ typedef enum Parsed_Statement_Kind {
     PARSED_STATEMENT_KIND__IF,
     PARSED_STATEMENT_KIND__IMPORT,
     PARSED_STATEMENT_KIND__LOOP,
+    PARSED_STATEMENT_KIND__PANIC,
     PARSED_STATEMENT_KIND__PROCEDURE,
     PARSED_STATEMENT_KIND__RAISE,
     PARSED_STATEMENT_KIND__RETURN,
@@ -534,6 +535,13 @@ typedef struct Parsed_Loop_Statement {
 } Parsed_Loop_Statement;
 
 Parsed_Statement *Parsed_Loop_Statement__create(Source_Location location, Parsed_Statement *body_statement);
+
+typedef struct Parsed_Panic_Statement {
+    Parsed_Statement super;
+    String_Token *message;
+} Parsed_Panic_Statement;
+
+Parsed_Statement *Parsed_Panic_Statement__create(Source_Location location, String_Token *message);
 
 typedef struct Parsed_Raise_Statement {
     Parsed_Statement super;

--- a/compiler/Parser.c
+++ b/compiler/Parser.c
@@ -1296,6 +1296,21 @@ Parsed_Statement *Parser__parse_loop_statement(Parser *self) {
 }
 
 /*
+panic
+    | "panic" STRING?
+*/
+Parsed_Statement *Parser__parse_panic_statement(Parser *self) {
+    Source_Location location = Parser__consume_token(self, Token__is_panic)->location;
+    String_Token *message = NULL;
+    if (!Parser__matches_end_of_line(self)) {
+        Parser__consume_space(self, 1);
+        message = (String_Token *)Parser__consume_token(self, Token__is_string);
+        location = Source_Location__merge(location, message->super.location);
+    }
+    return Parsed_Panic_Statement__create(location, message);
+}
+
+/*
 while
     | "while" expression block
 */
@@ -1382,6 +1397,7 @@ statement
     | if
     | import
     | loop
+    | panic
     | procedure
     | raise
     | return
@@ -1449,6 +1465,10 @@ Parsed_Statement *Parser__parse_statement(Parser *self) {
 
     if (Parser__matches_one(self, Token__is_const)) {
         return Parser__parse_constant_statement(self);
+    }
+
+    if (Parser__matches_one(self, Token__is_panic)) {
+        return Parser__parse_panic_statement(self);
     }
 
     Parsed_Expression *expression = Parser__parse_expression(self);

--- a/compiler/Token.c
+++ b/compiler/Token.c
@@ -186,6 +186,10 @@ bool Token__is_package(Token *self) {
     return Token__is_keyword(self, "package");
 }
 
+bool Token__is_panic(Token *self) {
+    return Token__is_keyword(self, "panic");
+}
+
 bool Token__is_proc(Token *self) {
     return Token__is_keyword(self, "proc");
 }

--- a/compiler/Token.h
+++ b/compiler/Token.h
@@ -144,6 +144,7 @@ bool Token__is_opening_paren(Token *self);
 bool Token__is_or(Token *self);
 bool Token__is_other(Token *self, char *lexeme);
 bool Token__is_package(Token *self);
+bool Token__is_panic(Token *self);
 bool Token__is_percent(Token *self);
 bool Token__is_plus(Token *self);
 bool Token__is_proc(Token *self);

--- a/docs/Code.md
+++ b/docs/Code.md
@@ -678,6 +678,7 @@ Rules:
 - Cases after `else` are an error
 - Duplicate cases are an error
 - A case alias follows the same aliasing rules as `is` aliases — it aliases the payload in place and is mutable exactly when the switched value is mutable
+- Over a `^Variant`, cases use the pointer form — see [Matching Through a Pointer](#matching-through-a-pointer)
 
 ### Pattern Matching — `is`
 
@@ -716,6 +717,36 @@ Rules:
 - The matched value must be addressable (a variable, member access, array item, or dereference) — the alias aliases the variant's payload in place, it is not a copy
 - An alias cannot be declared under `or` or `not`, where the match is not guaranteed
 - An alias is mutable exactly when the matched value is mutable — assigning to it writes the variant's payload in place
+
+### Matching Through a Pointer
+
+When the matched value is a pointer to a variant (`^Variant`) — in either a `switch` or an `is` — *every* case is written as a pointer type. A payload case binds its alias as a pointer to the payload; the empty case is `^nil`:
+
+```code
+let pointer = ^value
+
+if pointer is ^i32 as number {
+    number.^ = number.^ + 1   // number has type ^i32
+}
+
+switch pointer {
+    is ^i32 as number {
+        number.^ = 0          // number has type ^i32
+    }
+    is ^bool as flag {
+        flag.^ = false        // flag has type ^bool
+    }
+    is ^nil {
+        // the variant holds no value
+    }
+}
+```
+
+Rules:
+- Every case carries the `^`, including the empty case (`^nil`) — the bare forms (`is i32`, `is nil`) are an error for a pointer-to-variant
+- A payload case selects that case and binds a `^T` pointing at the payload; read and write it through `.^`, and a write updates the variant's payload in place
+- The matched expression need not be addressable itself — a pointer already refers to stable storage
+- A null pointer is not a match case here; null handling is separate (planned null-safety)
 
 ### Negated Check — `is not`
 

--- a/docs/Code.md
+++ b/docs/Code.md
@@ -351,6 +351,15 @@ return value   // return with a value
 return         // return from a void procedure
 ```
 
+### panic
+
+```code
+panic "Not supported yet"   // with a message
+panic                       // without a message
+```
+
+Terminates the program immediately: writes `<file>:<line>: Panic! <message>` to `stderr` and exits with status 1, where `<file>:<line>` is the location of the `panic` statement itself. The message must be a string literal. Like `return`, `panic` ends the control flow path it is on, so it satisfies the "missing return statement" check.
+
 ---
 
 ## Struct Types

--- a/tests/09__variant/018__if_as_pointer/test.code
+++ b/tests/09__variant/018__if_as_pointer/test.code
@@ -1,0 +1,15 @@
+type Value = variant {
+    bool
+    i32
+}
+
+proc main() -> i32 {
+    let value: Value = 42
+    let pointer = ^value
+
+    if pointer is ^i32 as integer {
+        return integer.^ - 42
+    }
+
+    return 1
+}

--- a/tests/09__variant/018__if_as_pointer/test.ir
+++ b/tests/09__variant/018__if_as_pointer/test.ir
@@ -1,0 +1,43 @@
+type test.Value = struct {
+  tag: i32
+  value: [1]u32
+}
+
+$test.main(): i32 {
+@1:
+  %value.ptr: [test.Value] = alloc test.Value
+  %1.ptr: [test.Value] = alloc test.Value
+  %2: [i32] = offset %1.ptr .tag
+  %3: i32 = const 2
+  store %2 %3
+  %4: i32 = const 42
+  %5: [[1]u32] = offset %1.ptr .value
+  %6: [i32] = cast %5
+  store %6 %4
+  %7: test.Value = load %1.ptr
+  store %value.ptr %7
+  %pointer.ptr: [[test.Value]] = alloc [test.Value]
+  store %pointer.ptr %value.ptr
+  %pointer.1: [test.Value] = load %pointer.ptr
+  %8: [i32] = offset %pointer.1 .tag
+  %9: i32 = load %8
+  %10: i32 = const 2
+  %11: bool = cmp_eq %9 %10
+  %12: [[1]u32] = offset %pointer.1 .value
+  %integer: [i32] = cast %12
+  br %11 @2 @3
+@2:
+  %14: i32 = load %integer
+  %15: i32 = const 42
+  %16: i32 = sub %14 %15
+  ret %16
+@3:
+  %17: i32 = const 1
+  ret %17
+}
+
+$main(): i32 {
+@1:
+  %1: i32 = call $test.main
+  ret %1
+}

--- a/tests/09__variant/019__if_as_pointer_assign/test.code
+++ b/tests/09__variant/019__if_as_pointer_assign/test.code
@@ -1,0 +1,19 @@
+type Value = variant {
+    bool
+    i32
+}
+
+proc main() -> i32 {
+    let value: Value = 42
+    let pointer = ^value
+
+    if pointer is ^i32 as number {
+        number.^ = 0
+    }
+
+    if value is i32 as number {
+        return number
+    }
+
+    return 1
+}

--- a/tests/09__variant/019__if_as_pointer_assign/test.ir
+++ b/tests/09__variant/019__if_as_pointer_assign/test.ir
@@ -1,0 +1,53 @@
+type test.Value = struct {
+  tag: i32
+  value: [1]u32
+}
+
+$test.main(): i32 {
+@1:
+  %value.ptr: [test.Value] = alloc test.Value
+  %1.ptr: [test.Value] = alloc test.Value
+  %2: [i32] = offset %1.ptr .tag
+  %3: i32 = const 2
+  store %2 %3
+  %4: i32 = const 42
+  %5: [[1]u32] = offset %1.ptr .value
+  %6: [i32] = cast %5
+  store %6 %4
+  %7: test.Value = load %1.ptr
+  store %value.ptr %7
+  %pointer.ptr: [[test.Value]] = alloc [test.Value]
+  store %pointer.ptr %value.ptr
+  %pointer.1: [test.Value] = load %pointer.ptr
+  %8: [i32] = offset %pointer.1 .tag
+  %9: i32 = load %8
+  %10: i32 = const 2
+  %11: bool = cmp_eq %9 %10
+  %12: [[1]u32] = offset %pointer.1 .value
+  %number: [i32] = cast %12
+  br %11 @2 @3
+@2:
+  %14: i32 = const 0
+  store %number %14
+  jmp @3
+@3:
+  %15: [i32] = offset %value.ptr .tag
+  %16: i32 = load %15
+  %17: i32 = const 2
+  %18: bool = cmp_eq %16 %17
+  %19: [[1]u32] = offset %value.ptr .value
+  %number.2.ptr: [i32] = cast %19
+  br %18 @4 @5
+@4:
+  %number.2.1: i32 = load %number.2.ptr
+  ret %number.2.1
+@5:
+  %21: i32 = const 1
+  ret %21
+}
+
+$main(): i32 {
+@1:
+  %1: i32 = call $test.main
+  ret %1
+}

--- a/tests/09__variant/020__is_pointer_value_case_type/test.code
+++ b/tests/09__variant/020__is_pointer_value_case_type/test.code
@@ -1,0 +1,15 @@
+type Value = variant {
+    bool
+    i32
+}
+
+proc main() -> i32 {
+    let value: Value = 42
+    let pointer = ^value
+
+    if pointer is i32 as number {
+        return number
+    }
+
+    return 1
+}

--- a/tests/09__variant/020__is_pointer_value_case_type/test.json
+++ b/tests/09__variant/020__is_pointer_value_case_type/test.json
@@ -1,0 +1,8 @@
+{
+    "compile": {
+        "error": 1,
+        "stderr": [
+            "tests/09__variant/020__is_pointer_value_case_type/test.code:10:19-22: A pointer-to-variant case must be a pointer type, such as ^i32"
+        ]
+    }
+}

--- a/tests/09__variant/021__switch_pointer/test.code
+++ b/tests/09__variant/021__switch_pointer/test.code
@@ -1,0 +1,27 @@
+type Value = variant {
+    bool
+    i32
+}
+
+proc main() -> i32 {
+    let value: Value = 42
+    let pointer = ^value
+
+    switch pointer {
+        is ^bool as flag {
+            return 1
+        }
+        is ^i32 as number {
+            number.^ = number.^ - 42
+        }
+        is ^nil {
+            return 2
+        }
+    }
+
+    if value is i32 as result {
+        return result
+    }
+
+    return 3
+}

--- a/tests/09__variant/021__switch_pointer/test.ir
+++ b/tests/09__variant/021__switch_pointer/test.ir
@@ -1,0 +1,73 @@
+type test.Value = struct {
+  tag: i32
+  value: [1]u32
+}
+
+$test.main(): i32 {
+@1:
+  %value.ptr: [test.Value] = alloc test.Value
+  %1.ptr: [test.Value] = alloc test.Value
+  %2: [i32] = offset %1.ptr .tag
+  %3: i32 = const 2
+  store %2 %3
+  %4: i32 = const 42
+  %5: [[1]u32] = offset %1.ptr .value
+  %6: [i32] = cast %5
+  store %6 %4
+  %7: test.Value = load %1.ptr
+  store %value.ptr %7
+  %pointer.ptr: [[test.Value]] = alloc [test.Value]
+  store %pointer.ptr %value.ptr
+  %pointer.1: [test.Value] = load %pointer.ptr
+  %8: [i32] = offset %pointer.1 .tag
+  %9: i32 = load %8
+  %10: i32 = const 1
+  %11: bool = cmp_eq %9 %10
+  br %11 @3 @4
+@3:
+  %12: [[1]u32] = offset %pointer.1 .value
+  %flag: [bool] = cast %12
+  %14: i32 = const 1
+  ret %14
+@4:
+  %15: i32 = const 2
+  %16: bool = cmp_eq %9 %15
+  br %16 @5 @6
+@5:
+  %17: [[1]u32] = offset %pointer.1 .value
+  %number: [i32] = cast %17
+  %19: i32 = load %number
+  %20: i32 = const 42
+  %21: i32 = sub %19 %20
+  store %number %21
+  jmp @2
+@6:
+  %22: i32 = const 0
+  %23: bool = cmp_eq %9 %22
+  br %23 @7 @8
+@7:
+  %24: i32 = const 2
+  ret %24
+@8:
+  jmp @2
+@2:
+  %25: [i32] = offset %value.ptr .tag
+  %26: i32 = load %25
+  %27: i32 = const 2
+  %28: bool = cmp_eq %26 %27
+  %29: [[1]u32] = offset %value.ptr .value
+  %result.ptr: [i32] = cast %29
+  br %28 @9 @10
+@9:
+  %result.1: i32 = load %result.ptr
+  ret %result.1
+@10:
+  %31: i32 = const 3
+  ret %31
+}
+
+$main(): i32 {
+@1:
+  %1: i32 = call $test.main
+  ret %1
+}

--- a/tests/19__panic/001__panic/test.code
+++ b/tests/19__panic/001__panic/test.code
@@ -1,0 +1,11 @@
+type FILE = external
+
+let std_err: ^FILE = external "stderr"
+
+proc exit(anon status: i32) = external
+
+proc fwrite(anon buffer: ^Any, anon size: usize, anon count: usize, anon file: ^FILE) -> usize = external
+
+proc main() -> i32 {
+    panic "Not supported yet"
+}

--- a/tests/19__panic/001__panic/test.ir
+++ b/tests/19__panic/001__panic/test.ir
@@ -1,0 +1,26 @@
+type FILE = opaque
+
+$stderr: [[FILE]] = external
+
+$exit: [proc (i32)] = external
+
+$fwrite: [proc ([Any], usize, usize, [FILE]): usize] = external
+
+$str_1: [*]u8 = "tests/19__panic/001__panic/test.code:10: Panic! Not supported yet\n"
+
+$test.main(): i32 {
+@1:
+  %1: [Any] = cast $str_1
+  %2: usize = const 1
+  %3: usize = const 66
+  %4: [FILE] = load $stderr
+  %5: usize = call $fwrite %1 %2 %3 %4
+  %6: i32 = const 1
+  call $exit %6
+}
+
+$main(): i32 {
+@1:
+  %1: i32 = call $test.main
+  ret %1
+}

--- a/tests/19__panic/001__panic/test.json
+++ b/tests/19__panic/001__panic/test.json
@@ -1,0 +1,8 @@
+{
+    "execute": {
+        "error": 1,
+        "stderr": [
+            "tests/19__panic/001__panic/test.code:10: Panic! Not supported yet"
+        ]
+    }
+}

--- a/tests/19__panic/002__panic_without_message/test.code
+++ b/tests/19__panic/002__panic_without_message/test.code
@@ -1,0 +1,11 @@
+type FILE = external
+
+let std_err: ^FILE = external "stderr"
+
+proc exit(anon status: i32) = external
+
+proc fwrite(anon buffer: ^Any, anon size: usize, anon count: usize, anon file: ^FILE) -> usize = external
+
+proc main() -> i32 {
+    panic
+}

--- a/tests/19__panic/002__panic_without_message/test.ir
+++ b/tests/19__panic/002__panic_without_message/test.ir
@@ -1,0 +1,26 @@
+type FILE = opaque
+
+$stderr: [[FILE]] = external
+
+$exit: [proc (i32)] = external
+
+$fwrite: [proc ([Any], usize, usize, [FILE]): usize] = external
+
+$str_1: [*]u8 = "tests/19__panic/002__panic_without_message/test.code:10: Panic!\n"
+
+$test.main(): i32 {
+@1:
+  %1: [Any] = cast $str_1
+  %2: usize = const 1
+  %3: usize = const 64
+  %4: [FILE] = load $stderr
+  %5: usize = call $fwrite %1 %2 %3 %4
+  %6: i32 = const 1
+  call $exit %6
+}
+
+$main(): i32 {
+@1:
+  %1: i32 = call $test.main
+  ret %1
+}

--- a/tests/19__panic/002__panic_without_message/test.json
+++ b/tests/19__panic/002__panic_without_message/test.json
@@ -1,0 +1,8 @@
+{
+    "execute": {
+        "error": 1,
+        "stderr": [
+            "tests/19__panic/002__panic_without_message/test.code:10: Panic!"
+        ]
+    }
+}

--- a/tests/99__calculator/calculator/expression/expression.code
+++ b/tests/99__calculator/calculator/expression/expression.code
@@ -42,22 +42,22 @@ type Subtraction = struct {
 
 proc (^Expression).span(self) -> source.Span {
     switch self {
-        is Number as variant {
+        is ^Number as variant {
             return variant.span
         }
-        is Addition as variant {
+        is ^Addition as variant {
             return variant.span
         }
-        is Division as variant {
+        is ^Division as variant {
             return variant.span
         }
-        is Multiplication as variant {
+        is ^Multiplication as variant {
             return variant.span
         }
-        is Subtraction as variant {
+        is ^Subtraction as variant {
             return variant.span
         }
-        is source.Error as variant {
+        is ^source.Error as variant {
             return variant.span
         }
         else {
@@ -69,25 +69,25 @@ proc (^Expression).span(self) -> source.Span {
 
 proc (^io.Writer).write_expression(self, anon expression: ^Expression) -> ^io.Writer {
     switch expression {
-        is Number as number {
+        is ^Number as number {
             return self.write_signed(signed: number.value)
         }
-        is Addition as addition {
+        is ^Addition as addition {
             return self.write_string("(").write_expression(addition.left).write_string(" + ").write_expression(addition.right).write_string(")")
         }
-        is Division as division {
+        is ^Division as division {
             return self.write_string("(").write_expression(division.left).write_string(" / ").write_expression(division.right).write_string(")")
         }
-        is Multiplication as multiplication {
+        is ^Multiplication as multiplication {
             return self.write_string("(").write_expression(multiplication.left).write_string(" * ").write_expression(multiplication.right).write_string(")")
         }
-        is Subtraction as subtraction {
+        is ^Subtraction as subtraction {
             return self.write_string("(").write_expression(subtraction.left).write_string(" - ").write_expression(subtraction.right).write_string(")")
         }
-        is source.Error as error {
+        is ^source.Error as error {
             return self.write_string("Error: ").write_string(error.message)
         }
-        is nil {
+        is ^nil {
             return self.write_string("Nil!")
         }
     }

--- a/tests/99__calculator/calculator/tokenizer/tokens.code
+++ b/tests/99__calculator/calculator/tokenizer/tokens.code
@@ -35,25 +35,25 @@ type Token = variant {
 
 proc (^Token).span(self) -> source.Span {
     switch self {
-        is expression.Number as variant {
+        is ^expression.Number as variant {
             return variant.span
         }
-        is Plus as variant {
+        is ^Plus as variant {
             return variant.span
         }
-        is Minus as variant {
+        is ^Minus as variant {
             return variant.span
         }
-        is Multiply as variant {
+        is ^Multiply as variant {
             return variant.span
         }
-        is Divide as variant {
+        is ^Divide as variant {
             return variant.span
         }
-        is Stop as variant {
+        is ^Stop as variant {
             return variant.span
         }
-        is source.Error as variant {
+        is ^source.Error as variant {
             return variant.span
         }
         else {
@@ -65,28 +65,28 @@ proc (^Token).span(self) -> source.Span {
 
 proc (^io.Writer).write_token(self, anon token: ^Token) -> ^io.Writer {
     switch token {
-        is expression.Number as number {
+        is ^expression.Number as number {
             return self.write_string("Number: ").write_signed(signed: number.value)
         }
-        is Plus {
+        is ^Plus {
             return self.write_string("Plus")
         }
-        is Minus {
+        is ^Minus {
             return self.write_string("Minus")
         }
-        is Multiply {
+        is ^Multiply {
             return self.write_string("Multiply")
         }
-        is Divide {
+        is ^Divide {
             return self.write_string("Divide")
         }
-        is Stop {
+        is ^Stop {
             return self.write_string("Stop")
         }
-        is source.Error as error {
+        is ^source.Error as error {
             return self.write_string("Error: ").write_string(error.message)
         }
-        is nil {
+        is ^nil {
             return self.write_string("Nil!")
         }
     }

--- a/tests/99__calculator/test.code
+++ b/tests/99__calculator/test.code
@@ -39,19 +39,19 @@ proc main(anon argc: i32, anon argv: [^][^]u8) -> i32 {
 
 proc evaluate(expression: ^expression.Expression) -> i32 {
     switch expression {
-        is expression.Number as number {
+        is ^expression.Number as number {
             return number.value
         }
-        is expression.Addition as addition {
+        is ^expression.Addition as addition {
             return evaluate(expression: addition.left) + evaluate(expression: addition.right)
         }
-        is expression.Division as division {
+        is ^expression.Division as division {
             return evaluate(expression: division.left) / evaluate(expression: division.right)
         }
-        is expression.Multiplication as multiplication {
+        is ^expression.Multiplication as multiplication {
             return evaluate(expression: multiplication.left) * evaluate(expression: multiplication.right)
         }
-        is expression.Subtraction as subtraction {
+        is ^expression.Subtraction as subtraction {
             return evaluate(expression: subtraction.left) - evaluate(expression: subtraction.right)
         }
         else {

--- a/tests/99__calculator/test.ir
+++ b/tests/99__calculator/test.ir
@@ -226,8 +226,8 @@ $test.evaluate+expression(%expression: [calculator.expression.Expression]): i32 
   br %4 @3 @4
 @3:
   %5: [[3]u64] = offset %expression .value
-  %number.ptr: [calculator.expression.Number] = cast %5
-  %7: [i32] = offset %number.ptr .value
+  %number: [calculator.expression.Number] = cast %5
+  %7: [i32] = offset %number .value
   %8: i32 = load %7
   ret %8
 @4:
@@ -236,11 +236,11 @@ $test.evaluate+expression(%expression: [calculator.expression.Expression]): i32 
   br %10 @5 @6
 @5:
   %11: [[3]u64] = offset %expression .value
-  %addition.ptr: [calculator.expression.Addition] = cast %11
-  %13: [[calculator.expression.Expression]] = offset %addition.ptr .left
+  %addition: [calculator.expression.Addition] = cast %11
+  %13: [[calculator.expression.Expression]] = offset %addition .left
   %14: [calculator.expression.Expression] = load %13
   %15: i32 = call $test.evaluate+expression %14
-  %16: [[calculator.expression.Expression]] = offset %addition.ptr .right
+  %16: [[calculator.expression.Expression]] = offset %addition .right
   %17: [calculator.expression.Expression] = load %16
   %18: i32 = call $test.evaluate+expression %17
   %19: i32 = add %15 %18
@@ -251,11 +251,11 @@ $test.evaluate+expression(%expression: [calculator.expression.Expression]): i32 
   br %21 @7 @8
 @7:
   %22: [[3]u64] = offset %expression .value
-  %division.ptr: [calculator.expression.Division] = cast %22
-  %24: [[calculator.expression.Expression]] = offset %division.ptr .left
+  %division: [calculator.expression.Division] = cast %22
+  %24: [[calculator.expression.Expression]] = offset %division .left
   %25: [calculator.expression.Expression] = load %24
   %26: i32 = call $test.evaluate+expression %25
-  %27: [[calculator.expression.Expression]] = offset %division.ptr .right
+  %27: [[calculator.expression.Expression]] = offset %division .right
   %28: [calculator.expression.Expression] = load %27
   %29: i32 = call $test.evaluate+expression %28
   %30: i32 = div %26 %29
@@ -266,11 +266,11 @@ $test.evaluate+expression(%expression: [calculator.expression.Expression]): i32 
   br %32 @9 @10
 @9:
   %33: [[3]u64] = offset %expression .value
-  %multiplication.ptr: [calculator.expression.Multiplication] = cast %33
-  %35: [[calculator.expression.Expression]] = offset %multiplication.ptr .left
+  %multiplication: [calculator.expression.Multiplication] = cast %33
+  %35: [[calculator.expression.Expression]] = offset %multiplication .left
   %36: [calculator.expression.Expression] = load %35
   %37: i32 = call $test.evaluate+expression %36
-  %38: [[calculator.expression.Expression]] = offset %multiplication.ptr .right
+  %38: [[calculator.expression.Expression]] = offset %multiplication .right
   %39: [calculator.expression.Expression] = load %38
   %40: i32 = call $test.evaluate+expression %39
   %41: i32 = mul %37 %40
@@ -281,11 +281,11 @@ $test.evaluate+expression(%expression: [calculator.expression.Expression]): i32 
   br %43 @11 @12
 @11:
   %44: [[3]u64] = offset %expression .value
-  %subtraction.ptr: [calculator.expression.Subtraction] = cast %44
-  %46: [[calculator.expression.Expression]] = offset %subtraction.ptr .left
+  %subtraction: [calculator.expression.Subtraction] = cast %44
+  %46: [[calculator.expression.Expression]] = offset %subtraction .left
   %47: [calculator.expression.Expression] = load %46
   %48: i32 = call $test.evaluate+expression %47
-  %49: [[calculator.expression.Expression]] = offset %subtraction.ptr .right
+  %49: [[calculator.expression.Expression]] = offset %subtraction .right
   %50: [calculator.expression.Expression] = load %49
   %51: i32 = call $test.evaluate+expression %50
   %52: i32 = sub %48 %51
@@ -306,8 +306,8 @@ $([calculator.expression.Expression]).span(%self): calculator.source.Span {
   br %4 @3 @4
 @3:
   %5: [[3]u64] = offset %self .value
-  %variant.ptr: [calculator.expression.Number] = cast %5
-  %7: [calculator.source.Span] = offset %variant.ptr .span
+  %variant: [calculator.expression.Number] = cast %5
+  %7: [calculator.source.Span] = offset %variant .span
   %8: calculator.source.Span = load %7
   ret %8
 @4:
@@ -316,8 +316,8 @@ $([calculator.expression.Expression]).span(%self): calculator.source.Span {
   br %10 @5 @6
 @5:
   %11: [[3]u64] = offset %self .value
-  %variant.2.ptr: [calculator.expression.Addition] = cast %11
-  %13: [calculator.source.Span] = offset %variant.2.ptr .span
+  %variant.2: [calculator.expression.Addition] = cast %11
+  %13: [calculator.source.Span] = offset %variant.2 .span
   %14: calculator.source.Span = load %13
   ret %14
 @6:
@@ -326,8 +326,8 @@ $([calculator.expression.Expression]).span(%self): calculator.source.Span {
   br %16 @7 @8
 @7:
   %17: [[3]u64] = offset %self .value
-  %variant.3.ptr: [calculator.expression.Division] = cast %17
-  %19: [calculator.source.Span] = offset %variant.3.ptr .span
+  %variant.3: [calculator.expression.Division] = cast %17
+  %19: [calculator.source.Span] = offset %variant.3 .span
   %20: calculator.source.Span = load %19
   ret %20
 @8:
@@ -336,8 +336,8 @@ $([calculator.expression.Expression]).span(%self): calculator.source.Span {
   br %22 @9 @10
 @9:
   %23: [[3]u64] = offset %self .value
-  %variant.4.ptr: [calculator.expression.Multiplication] = cast %23
-  %25: [calculator.source.Span] = offset %variant.4.ptr .span
+  %variant.4: [calculator.expression.Multiplication] = cast %23
+  %25: [calculator.source.Span] = offset %variant.4 .span
   %26: calculator.source.Span = load %25
   ret %26
 @10:
@@ -346,8 +346,8 @@ $([calculator.expression.Expression]).span(%self): calculator.source.Span {
   br %28 @11 @12
 @11:
   %29: [[3]u64] = offset %self .value
-  %variant.5.ptr: [calculator.expression.Subtraction] = cast %29
-  %31: [calculator.source.Span] = offset %variant.5.ptr .span
+  %variant.5: [calculator.expression.Subtraction] = cast %29
+  %31: [calculator.source.Span] = offset %variant.5 .span
   %32: calculator.source.Span = load %31
   ret %32
 @12:
@@ -356,8 +356,8 @@ $([calculator.expression.Expression]).span(%self): calculator.source.Span {
   br %34 @13 @14
 @13:
   %35: [[3]u64] = offset %self .value
-  %variant.6.ptr: [calculator.source.Error] = cast %35
-  %37: [calculator.source.Span] = offset %variant.6.ptr .span
+  %variant.6: [calculator.source.Error] = cast %35
+  %37: [calculator.source.Span] = offset %variant.6 .span
   %38: calculator.source.Span = load %37
   ret %38
 @14:
@@ -376,8 +376,8 @@ $([io.Writer]).write_expression+anon(%self, %expression: [calculator.expression.
   br %4 @3 @4
 @3:
   %5: [[3]u64] = offset %expression .value
-  %number.ptr: [calculator.expression.Number] = cast %5
-  %7: [i32] = offset %number.ptr .value
+  %number: [calculator.expression.Number] = cast %5
+  %7: [i32] = offset %number .value
   %8: i32 = load %7
   %9: [io.Writer] = call $([io.Writer]).write_signed+signed %self %8
   ret %9
@@ -387,17 +387,17 @@ $([io.Writer]).write_expression+anon(%self, %expression: [calculator.expression.
   br %11 @5 @6
 @5:
   %12: [[3]u64] = offset %expression .value
-  %addition.ptr: [calculator.expression.Addition] = cast %12
+  %addition: [calculator.expression.Addition] = cast %12
   %14: usize = const 1
   %15: String = struct .data $str_3 .length %14
   %16: [io.Writer] = call $([io.Writer]).write_string+anon %self %15
-  %17: [[calculator.expression.Expression]] = offset %addition.ptr .left
+  %17: [[calculator.expression.Expression]] = offset %addition .left
   %18: [calculator.expression.Expression] = load %17
   %19: [io.Writer] = call $([io.Writer]).write_expression+anon %16 %18
   %20: usize = const 3
   %21: String = struct .data $str_4 .length %20
   %22: [io.Writer] = call $([io.Writer]).write_string+anon %19 %21
-  %23: [[calculator.expression.Expression]] = offset %addition.ptr .right
+  %23: [[calculator.expression.Expression]] = offset %addition .right
   %24: [calculator.expression.Expression] = load %23
   %25: [io.Writer] = call $([io.Writer]).write_expression+anon %22 %24
   %26: usize = const 1
@@ -410,17 +410,17 @@ $([io.Writer]).write_expression+anon(%self, %expression: [calculator.expression.
   br %30 @7 @8
 @7:
   %31: [[3]u64] = offset %expression .value
-  %division.ptr: [calculator.expression.Division] = cast %31
+  %division: [calculator.expression.Division] = cast %31
   %33: usize = const 1
   %34: String = struct .data $str_3 .length %33
   %35: [io.Writer] = call $([io.Writer]).write_string+anon %self %34
-  %36: [[calculator.expression.Expression]] = offset %division.ptr .left
+  %36: [[calculator.expression.Expression]] = offset %division .left
   %37: [calculator.expression.Expression] = load %36
   %38: [io.Writer] = call $([io.Writer]).write_expression+anon %35 %37
   %39: usize = const 3
   %40: String = struct .data $str_6 .length %39
   %41: [io.Writer] = call $([io.Writer]).write_string+anon %38 %40
-  %42: [[calculator.expression.Expression]] = offset %division.ptr .right
+  %42: [[calculator.expression.Expression]] = offset %division .right
   %43: [calculator.expression.Expression] = load %42
   %44: [io.Writer] = call $([io.Writer]).write_expression+anon %41 %43
   %45: usize = const 1
@@ -433,17 +433,17 @@ $([io.Writer]).write_expression+anon(%self, %expression: [calculator.expression.
   br %49 @9 @10
 @9:
   %50: [[3]u64] = offset %expression .value
-  %multiplication.ptr: [calculator.expression.Multiplication] = cast %50
+  %multiplication: [calculator.expression.Multiplication] = cast %50
   %52: usize = const 1
   %53: String = struct .data $str_3 .length %52
   %54: [io.Writer] = call $([io.Writer]).write_string+anon %self %53
-  %55: [[calculator.expression.Expression]] = offset %multiplication.ptr .left
+  %55: [[calculator.expression.Expression]] = offset %multiplication .left
   %56: [calculator.expression.Expression] = load %55
   %57: [io.Writer] = call $([io.Writer]).write_expression+anon %54 %56
   %58: usize = const 3
   %59: String = struct .data $str_7 .length %58
   %60: [io.Writer] = call $([io.Writer]).write_string+anon %57 %59
-  %61: [[calculator.expression.Expression]] = offset %multiplication.ptr .right
+  %61: [[calculator.expression.Expression]] = offset %multiplication .right
   %62: [calculator.expression.Expression] = load %61
   %63: [io.Writer] = call $([io.Writer]).write_expression+anon %60 %62
   %64: usize = const 1
@@ -456,17 +456,17 @@ $([io.Writer]).write_expression+anon(%self, %expression: [calculator.expression.
   br %68 @11 @12
 @11:
   %69: [[3]u64] = offset %expression .value
-  %subtraction.ptr: [calculator.expression.Subtraction] = cast %69
+  %subtraction: [calculator.expression.Subtraction] = cast %69
   %71: usize = const 1
   %72: String = struct .data $str_3 .length %71
   %73: [io.Writer] = call $([io.Writer]).write_string+anon %self %72
-  %74: [[calculator.expression.Expression]] = offset %subtraction.ptr .left
+  %74: [[calculator.expression.Expression]] = offset %subtraction .left
   %75: [calculator.expression.Expression] = load %74
   %76: [io.Writer] = call $([io.Writer]).write_expression+anon %73 %75
   %77: usize = const 3
   %78: String = struct .data $str_8 .length %77
   %79: [io.Writer] = call $([io.Writer]).write_string+anon %76 %78
-  %80: [[calculator.expression.Expression]] = offset %subtraction.ptr .right
+  %80: [[calculator.expression.Expression]] = offset %subtraction .right
   %81: [calculator.expression.Expression] = load %80
   %82: [io.Writer] = call $([io.Writer]).write_expression+anon %79 %81
   %83: usize = const 1
@@ -479,11 +479,11 @@ $([io.Writer]).write_expression+anon(%self, %expression: [calculator.expression.
   br %87 @13 @14
 @13:
   %88: [[3]u64] = offset %expression .value
-  %error.ptr: [calculator.source.Error] = cast %88
+  %error: [calculator.source.Error] = cast %88
   %90: usize = const 7
   %91: String = struct .data $str_9 .length %90
   %92: [io.Writer] = call $([io.Writer]).write_string+anon %self %91
-  %93: [String] = offset %error.ptr .message
+  %93: [String] = offset %error .message
   %94: String = load %93
   %95: [io.Writer] = call $([io.Writer]).write_string+anon %92 %94
   ret %95
@@ -779,8 +779,8 @@ $([calculator.tokenizer.Token]).span(%self): calculator.source.Span {
   br %4 @3 @4
 @3:
   %5: [[3]u64] = offset %self .value
-  %variant.ptr: [calculator.expression.Number] = cast %5
-  %7: [calculator.source.Span] = offset %variant.ptr .span
+  %variant: [calculator.expression.Number] = cast %5
+  %7: [calculator.source.Span] = offset %variant .span
   %8: calculator.source.Span = load %7
   ret %8
 @4:
@@ -789,8 +789,8 @@ $([calculator.tokenizer.Token]).span(%self): calculator.source.Span {
   br %10 @5 @6
 @5:
   %11: [[3]u64] = offset %self .value
-  %variant.2.ptr: [calculator.tokenizer.Plus] = cast %11
-  %13: [calculator.source.Span] = offset %variant.2.ptr .span
+  %variant.2: [calculator.tokenizer.Plus] = cast %11
+  %13: [calculator.source.Span] = offset %variant.2 .span
   %14: calculator.source.Span = load %13
   ret %14
 @6:
@@ -799,8 +799,8 @@ $([calculator.tokenizer.Token]).span(%self): calculator.source.Span {
   br %16 @7 @8
 @7:
   %17: [[3]u64] = offset %self .value
-  %variant.3.ptr: [calculator.tokenizer.Minus] = cast %17
-  %19: [calculator.source.Span] = offset %variant.3.ptr .span
+  %variant.3: [calculator.tokenizer.Minus] = cast %17
+  %19: [calculator.source.Span] = offset %variant.3 .span
   %20: calculator.source.Span = load %19
   ret %20
 @8:
@@ -809,8 +809,8 @@ $([calculator.tokenizer.Token]).span(%self): calculator.source.Span {
   br %22 @9 @10
 @9:
   %23: [[3]u64] = offset %self .value
-  %variant.4.ptr: [calculator.tokenizer.Multiply] = cast %23
-  %25: [calculator.source.Span] = offset %variant.4.ptr .span
+  %variant.4: [calculator.tokenizer.Multiply] = cast %23
+  %25: [calculator.source.Span] = offset %variant.4 .span
   %26: calculator.source.Span = load %25
   ret %26
 @10:
@@ -819,8 +819,8 @@ $([calculator.tokenizer.Token]).span(%self): calculator.source.Span {
   br %28 @11 @12
 @11:
   %29: [[3]u64] = offset %self .value
-  %variant.5.ptr: [calculator.tokenizer.Divide] = cast %29
-  %31: [calculator.source.Span] = offset %variant.5.ptr .span
+  %variant.5: [calculator.tokenizer.Divide] = cast %29
+  %31: [calculator.source.Span] = offset %variant.5 .span
   %32: calculator.source.Span = load %31
   ret %32
 @12:
@@ -829,8 +829,8 @@ $([calculator.tokenizer.Token]).span(%self): calculator.source.Span {
   br %34 @13 @14
 @13:
   %35: [[3]u64] = offset %self .value
-  %variant.6.ptr: [calculator.tokenizer.Stop] = cast %35
-  %37: [calculator.source.Span] = offset %variant.6.ptr .span
+  %variant.6: [calculator.tokenizer.Stop] = cast %35
+  %37: [calculator.source.Span] = offset %variant.6 .span
   %38: calculator.source.Span = load %37
   ret %38
 @14:
@@ -839,8 +839,8 @@ $([calculator.tokenizer.Token]).span(%self): calculator.source.Span {
   br %40 @15 @16
 @15:
   %41: [[3]u64] = offset %self .value
-  %variant.7.ptr: [calculator.source.Error] = cast %41
-  %43: [calculator.source.Span] = offset %variant.7.ptr .span
+  %variant.7: [calculator.source.Error] = cast %41
+  %43: [calculator.source.Span] = offset %variant.7 .span
   %44: calculator.source.Span = load %43
   ret %44
 @16:
@@ -859,11 +859,11 @@ $([io.Writer]).write_token+anon(%self, %token: [calculator.tokenizer.Token]): [i
   br %4 @3 @4
 @3:
   %5: [[3]u64] = offset %token .value
-  %number.ptr: [calculator.expression.Number] = cast %5
+  %number: [calculator.expression.Number] = cast %5
   %7: usize = const 8
   %8: String = struct .data $str_12 .length %7
   %9: [io.Writer] = call $([io.Writer]).write_string+anon %self %8
-  %10: [i32] = offset %number.ptr .value
+  %10: [i32] = offset %number .value
   %11: i32 = load %10
   %12: [io.Writer] = call $([io.Writer]).write_signed+signed %9 %11
   ret %12
@@ -918,11 +918,11 @@ $([io.Writer]).write_token+anon(%self, %token: [calculator.tokenizer.Token]): [i
   br %39 @15 @16
 @15:
   %40: [[3]u64] = offset %token .value
-  %error.ptr: [calculator.source.Error] = cast %40
+  %error: [calculator.source.Error] = cast %40
   %42: usize = const 7
   %43: String = struct .data $str_9 .length %42
   %44: [io.Writer] = call $([io.Writer]).write_string+anon %self %43
-  %45: [String] = offset %error.ptr .message
+  %45: [String] = offset %error .message
   %46: String = load %45
   %47: [io.Writer] = call $([io.Writer]).write_string+anon %44 %46
   ret %47


### PR DESCRIPTION
## Language changes

### New `panic` statement
```code
panic "Not supported yet"   // with a message
panic                       // without a message
```

Terminates the program immediately: writes `<file>:<line>: Panic! <message>` to `stderr` and exits with status 1.

### Matching a variant through a pointer

```code
if pointer is ^i32 as number {
    number.^ = number.^ + 1   // number has type ^i32
}

switch pointer {
    is ^i32 as number {
      number.^ = 0
    }
    is ^bool as flag  {
      flag.^ = false
    }
    is ^nil {
      // the variant holds no value
    }
}
```
